### PR TITLE
Refactor cell grid storage to contiguous memory with 2D/3D indexing support

### DIFF
--- a/visualiserProxy/ContiguousGrid.h
+++ b/visualiserProxy/ContiguousGrid.h
@@ -1,181 +1,169 @@
 /** @file ContiguousGrid.h
- * @brief Lightweight contiguous N-dimensional storage with chained indexing.
+ * @brief Lightweight contiguous grid storage with row and layer access.
  *
  * This is a temporary in-tree replacement for std::mdspan while the project
  * still needs to build with toolchains that do not provide it yet. */
 
 #pragma once
 
-#include <array>
 #include <cassert>
-#include <concepts>
 #include <cstddef>
 #include <vector>
 
 /** @class ContiguousGrid
- * @brief Stores N-dimensional data in a single contiguous std::vector.
+ * @brief Stores grid data in a single contiguous std::vector.
  *
- * The class offers both chained indexing (`grid[y][x]`, `grid[z][y][x]`) and
- * direct multi-index access (`grid(y, x)`, `grid(z, y, x)`), while keeping the
- * data in a compact row-major layout.
- *
- * @note This helper is intended as a temporary solution until std::mdspan is
- *       reliably available in the compilers used by this project. */
-template<typename T, std::size_t Dimensions>
+ * The container keeps a row-major layout with an optional third dimension.
+ * The layer count defaults to 1 so the same type can back the current 2D code
+ * and future 3D-oriented access patterns. */
+template<typename T>
 class ContiguousGrid
 {
-    static_assert(Dimensions >= 2, "ContiguousGrid is intended for 2D or higher-dimensional storage.");
-
 public:
     using value_type = T;
     using size_type = std::size_t;
 
-    template<typename ElementType, std::size_t RemainingDimensions>
-    class Slice
+    /** @class RowProxy
+     * @brief Provides column-based access to a single row of the grid. */
+    template<typename ElementType>
+    class RowProxy
     {
     public:
+        /** @brief Returns the number of columns available in this row. */
         [[nodiscard]] size_type size() const noexcept
         {
-            return extents_[0];
+            return columnCount_;
         }
 
-        [[nodiscard]] decltype(auto) operator[](size_type index) const noexcept
+        /** @brief Returns the element from the first layer at the given column. */
+        [[nodiscard]] decltype(auto) operator[](size_type column) const noexcept
         {
-            assert(index < size());
+            assert(column < columnCount_);
+            return (rowData_[column * layerCount_]);
+        }
 
-            if constexpr (RemainingDimensions == 1)
-            {
-                return (data_[index]);
-            }
-            else
-            {
-                return Slice<ElementType, RemainingDimensions - 1>(data_ + index * strides_[0], extents_ + 1, strides_ + 1);
-            }
+        /** @brief Returns the element at the given column and layer. */
+        [[nodiscard]] decltype(auto) operator[](size_type column, size_type layer) const noexcept
+        {
+            assert(column < columnCount_);
+            assert(layer < layerCount_);
+            return (rowData_[column * layerCount_ + layer]);
         }
 
     private:
         friend class ContiguousGrid;
 
-        Slice(ElementType* data, const size_type* extents, const size_type* strides) noexcept
-            : data_(data)
-            , extents_(extents)
-            , strides_(strides)
+        /** @brief Creates a row proxy for internal contiguous storage access. */
+        RowProxy(ElementType* rowData, size_type columnCount, size_type layerCount) noexcept
+            : rowData_(rowData)
+            , columnCount_(columnCount)
+            , layerCount_(layerCount)
         {
         }
 
-        ElementType* data_ = nullptr;
-        const size_type* extents_ = nullptr;
-        const size_type* strides_ = nullptr;
+        ElementType* rowData_ = nullptr;
+        size_type columnCount_ = 0;
+        size_type layerCount_ = 1;
     };
 
+    /** @brief Creates an empty grid. */
     ContiguousGrid() = default;
 
-    explicit ContiguousGrid(const std::array<size_type, Dimensions>& extents)
+    /** @brief Creates a grid with the given row, column and layer counts. */
+    explicit ContiguousGrid(size_type rowCount, size_type columnCount, size_type layerCount = 1)
     {
-        resize(extents);
+        resize(rowCount, columnCount, layerCount);
     }
 
-    void resize(const std::array<size_type, Dimensions>& extents)
+    /** @brief Resizes the grid and value-initializes the contiguous storage. */
+    void resize(size_type rowCount, size_type columnCount, size_type layerCount = 1)
     {
-        extents_ = extents;
-        recomputeStrides();
-        storage_.resize(totalSize());
+        rowCount_ = rowCount;
+        columnCount_ = columnCount;
+        layerCount_ = layerCount;
+        storage_.resize(rowCount_ * columnCount_ * layerCount_);
     }
 
-    template<typename... Sizes>
-        requires(sizeof...(Sizes) == Dimensions && (std::integral<Sizes> && ...))
-    void resize(Sizes... sizes)
-    {
-        resize(std::array<size_type, Dimensions>{toSize(sizes)...});
-    }
-
+    /** @brief Returns the number of rows to preserve `grid[row][column]` usage. */
     [[nodiscard]] size_type size() const noexcept
     {
-        return extents_[0];
+        return rowCount_;
     }
 
+    /** @brief Returns true when the grid contains no elements. */
     [[nodiscard]] bool empty() const noexcept
     {
         return storage_.empty();
     }
 
-    [[nodiscard]] const std::array<size_type, Dimensions>& extents() const noexcept
+    /** @brief Returns the configured number of rows. */
+    [[nodiscard]] size_type rowCount() const noexcept
     {
-        return extents_;
+        return rowCount_;
     }
 
+    /** @brief Returns the configured number of columns. */
+    [[nodiscard]] size_type columnCount() const noexcept
+    {
+        return columnCount_;
+    }
+
+    /** @brief Returns the configured number of layers. */
+    [[nodiscard]] size_type layerCount() const noexcept
+    {
+        return layerCount_;
+    }
+
+    /** @brief Returns a mutable pointer to the contiguous storage buffer. */
     [[nodiscard]] value_type* data() noexcept
     {
         return storage_.data();
     }
 
+    /** @brief Returns a const pointer to the contiguous storage buffer. */
     [[nodiscard]] const value_type* data() const noexcept
     {
         return storage_.data();
     }
 
-    [[nodiscard]] auto operator[](size_type index) noexcept
+    /** @brief Returns a mutable row proxy for `grid[row][column]` access. */
+    [[nodiscard]] RowProxy<value_type> operator[](size_type row) noexcept
     {
-        assert(index < size());
-        return Slice<value_type, Dimensions - 1>(storage_.data() + index * strides_[0], extents_.data() + 1, strides_.data() + 1);
+        assert(row < rowCount_);
+        return RowProxy<value_type>(storage_.data() + row * columnCount_ * layerCount_, columnCount_, layerCount_);
     }
 
-    [[nodiscard]] auto operator[](size_type index) const noexcept
+    /** @brief Returns a const row proxy for `grid[row][column]` access. */
+    [[nodiscard]] RowProxy<const value_type> operator[](size_type row) const noexcept
     {
-        assert(index < size());
-        return Slice<const value_type, Dimensions - 1>(storage_.data() + index * strides_[0], extents_.data() + 1, strides_.data() + 1);
+        assert(row < rowCount_);
+        return RowProxy<const value_type>(storage_.data() + row * columnCount_ * layerCount_, columnCount_, layerCount_);
     }
 
-    template<typename... Indices>
-        requires(sizeof...(Indices) == Dimensions && (std::integral<Indices> && ...))
-    [[nodiscard]] value_type& operator()(Indices... indices) noexcept
+    /** @brief Returns a mutable element using C++23 multidimensional subscript syntax. */
+    [[nodiscard]] value_type& operator[](size_type row, size_type column, size_type layer = 0) noexcept
     {
-        return storage_[flatten(std::array<size_type, Dimensions>{toSize(indices)...})];
+        return storage_[flatIndex(row, column, layer)];
     }
 
-    template<typename... Indices>
-        requires(sizeof...(Indices) == Dimensions && (std::integral<Indices> && ...))
-    [[nodiscard]] const value_type& operator()(Indices... indices) const noexcept
+    /** @brief Returns a const element using C++23 multidimensional subscript syntax. */
+    [[nodiscard]] const value_type& operator[](size_type row, size_type column, size_type layer = 0) const noexcept
     {
-        return storage_[flatten(std::array<size_type, Dimensions>{toSize(indices)...})];
+        return storage_[flatIndex(row, column, layer)];
     }
 
 private:
-    [[nodiscard]] static constexpr size_type toSize(std::integral auto value) noexcept
+    /** @brief Computes the storage offset for a row, column and layer triplet. */
+    [[nodiscard]] size_type flatIndex(size_type row, size_type column, size_type layer) const noexcept
     {
-        return static_cast<size_type>(value);
-    }
-
-    void recomputeStrides() noexcept
-    {
-        size_type stride = 1;
-        for (size_type i = Dimensions; i-- > 0;)
-        {
-            strides_[i] = stride;
-            stride *= extents_[i];
-        }
-    }
-
-    [[nodiscard]] size_type totalSize() const noexcept
-    {
-        size_type size = 1;
-        for (const size_type extent : extents_)
-            size *= extent;
-        return size;
-    }
-
-    [[nodiscard]] size_type flatten(const std::array<size_type, Dimensions>& indices) const noexcept
-    {
-        size_type offset = 0;
-        for (size_type i = 0; i < Dimensions; ++i)
-        {
-            assert(indices[i] < extents_[i]);
-            offset += indices[i] * strides_[i];
-        }
-        return offset;
+        assert(row < rowCount_);
+        assert(column < columnCount_);
+        assert(layer < layerCount_);
+        return (row * columnCount_ + column) * layerCount_ + layer;
     }
 
     std::vector<value_type> storage_;
-    std::array<size_type, Dimensions> extents_{};
-    std::array<size_type, Dimensions> strides_{};
+    size_type rowCount_ = 0;
+    size_type columnCount_ = 0;
+    size_type layerCount_ = 1;
 };

--- a/visualiserProxy/ContiguousGrid.h
+++ b/visualiserProxy/ContiguousGrid.h
@@ -1,0 +1,181 @@
+/** @file ContiguousGrid.h
+ * @brief Lightweight contiguous N-dimensional storage with chained indexing.
+ *
+ * This is a temporary in-tree replacement for std::mdspan while the project
+ * still needs to build with toolchains that do not provide it yet. */
+
+#pragma once
+
+#include <array>
+#include <cassert>
+#include <concepts>
+#include <cstddef>
+#include <vector>
+
+/** @class ContiguousGrid
+ * @brief Stores N-dimensional data in a single contiguous std::vector.
+ *
+ * The class offers both chained indexing (`grid[y][x]`, `grid[z][y][x]`) and
+ * direct multi-index access (`grid(y, x)`, `grid(z, y, x)`), while keeping the
+ * data in a compact row-major layout.
+ *
+ * @note This helper is intended as a temporary solution until std::mdspan is
+ *       reliably available in the compilers used by this project. */
+template<typename T, std::size_t Dimensions>
+class ContiguousGrid
+{
+    static_assert(Dimensions >= 2, "ContiguousGrid is intended for 2D or higher-dimensional storage.");
+
+public:
+    using value_type = T;
+    using size_type = std::size_t;
+
+    template<typename ElementType, std::size_t RemainingDimensions>
+    class Slice
+    {
+    public:
+        [[nodiscard]] size_type size() const noexcept
+        {
+            return extents_[0];
+        }
+
+        [[nodiscard]] decltype(auto) operator[](size_type index) const noexcept
+        {
+            assert(index < size());
+
+            if constexpr (RemainingDimensions == 1)
+            {
+                return (data_[index]);
+            }
+            else
+            {
+                return Slice<ElementType, RemainingDimensions - 1>(data_ + index * strides_[0], extents_ + 1, strides_ + 1);
+            }
+        }
+
+    private:
+        friend class ContiguousGrid;
+
+        Slice(ElementType* data, const size_type* extents, const size_type* strides) noexcept
+            : data_(data)
+            , extents_(extents)
+            , strides_(strides)
+        {
+        }
+
+        ElementType* data_ = nullptr;
+        const size_type* extents_ = nullptr;
+        const size_type* strides_ = nullptr;
+    };
+
+    ContiguousGrid() = default;
+
+    explicit ContiguousGrid(const std::array<size_type, Dimensions>& extents)
+    {
+        resize(extents);
+    }
+
+    void resize(const std::array<size_type, Dimensions>& extents)
+    {
+        extents_ = extents;
+        recomputeStrides();
+        storage_.resize(totalSize());
+    }
+
+    template<typename... Sizes>
+        requires(sizeof...(Sizes) == Dimensions && (std::integral<Sizes> && ...))
+    void resize(Sizes... sizes)
+    {
+        resize(std::array<size_type, Dimensions>{toSize(sizes)...});
+    }
+
+    [[nodiscard]] size_type size() const noexcept
+    {
+        return extents_[0];
+    }
+
+    [[nodiscard]] bool empty() const noexcept
+    {
+        return storage_.empty();
+    }
+
+    [[nodiscard]] const std::array<size_type, Dimensions>& extents() const noexcept
+    {
+        return extents_;
+    }
+
+    [[nodiscard]] value_type* data() noexcept
+    {
+        return storage_.data();
+    }
+
+    [[nodiscard]] const value_type* data() const noexcept
+    {
+        return storage_.data();
+    }
+
+    [[nodiscard]] auto operator[](size_type index) noexcept
+    {
+        assert(index < size());
+        return Slice<value_type, Dimensions - 1>(storage_.data() + index * strides_[0], extents_.data() + 1, strides_.data() + 1);
+    }
+
+    [[nodiscard]] auto operator[](size_type index) const noexcept
+    {
+        assert(index < size());
+        return Slice<const value_type, Dimensions - 1>(storage_.data() + index * strides_[0], extents_.data() + 1, strides_.data() + 1);
+    }
+
+    template<typename... Indices>
+        requires(sizeof...(Indices) == Dimensions && (std::integral<Indices> && ...))
+    [[nodiscard]] value_type& operator()(Indices... indices) noexcept
+    {
+        return storage_[flatten(std::array<size_type, Dimensions>{toSize(indices)...})];
+    }
+
+    template<typename... Indices>
+        requires(sizeof...(Indices) == Dimensions && (std::integral<Indices> && ...))
+    [[nodiscard]] const value_type& operator()(Indices... indices) const noexcept
+    {
+        return storage_[flatten(std::array<size_type, Dimensions>{toSize(indices)...})];
+    }
+
+private:
+    [[nodiscard]] static constexpr size_type toSize(std::integral auto value) noexcept
+    {
+        return static_cast<size_type>(value);
+    }
+
+    void recomputeStrides() noexcept
+    {
+        size_type stride = 1;
+        for (size_type i = Dimensions; i-- > 0;)
+        {
+            strides_[i] = stride;
+            stride *= extents_[i];
+        }
+    }
+
+    [[nodiscard]] size_type totalSize() const noexcept
+    {
+        size_type size = 1;
+        for (const size_type extent : extents_)
+            size *= extent;
+        return size;
+    }
+
+    [[nodiscard]] size_type flatten(const std::array<size_type, Dimensions>& indices) const noexcept
+    {
+        size_type offset = 0;
+        for (size_type i = 0; i < Dimensions; ++i)
+        {
+            assert(indices[i] < extents_[i]);
+            offset += indices[i] * strides_[i];
+        }
+        return offset;
+    }
+
+    std::vector<value_type> storage_;
+    std::array<size_type, Dimensions> extents_{};
+    std::array<size_type, Dimensions> strides_{};
+};

--- a/visualiserProxy/ContiguousGrid.h
+++ b/visualiserProxy/ContiguousGrid.h
@@ -140,14 +140,26 @@ public:
         return RowProxy<const value_type>(storage_.data() + row * columnCount_ * layerCount_, columnCount_, layerCount_);
     }
 
-    /** @brief Returns a mutable element using C++23 multidimensional subscript syntax. */
-    [[nodiscard]] value_type& operator[](size_type row, size_type column, size_type layer = 0) noexcept
+    /** @brief Returns a mutable element from the first layer using C++23 multidimensional subscript syntax. */
+    [[nodiscard]] value_type& operator[](size_type row, size_type column) noexcept
+    {
+        return storage_[flatIndex(row, column, 0)];
+    }
+
+    /** @brief Returns a const element from the first layer using C++23 multidimensional subscript syntax. */
+    [[nodiscard]] const value_type& operator[](size_type row, size_type column) const noexcept
+    {
+        return storage_[flatIndex(row, column, 0)];
+    }
+
+    /** @brief Returns a mutable element from the given layer using C++23 multidimensional subscript syntax. */
+    [[nodiscard]] value_type& operator[](size_type row, size_type column, size_type layer) noexcept
     {
         return storage_[flatIndex(row, column, layer)];
     }
 
-    /** @brief Returns a const element using C++23 multidimensional subscript syntax. */
-    [[nodiscard]] const value_type& operator[](size_type row, size_type column, size_type layer = 0) const noexcept
+    /** @brief Returns a const element from the given layer using C++23 multidimensional subscript syntax. */
+    [[nodiscard]] const value_type& operator[](size_type row, size_type column, size_type layer) const noexcept
     {
         return storage_[flatIndex(row, column, layer)];
     }

--- a/visualiserProxy/SceneWidgetVisualizerProxy.h
+++ b/visualiserProxy/SceneWidgetVisualizerProxy.h
@@ -155,7 +155,7 @@ public:
 private:
     const std::string m_modelName;
 
-    Visualizer visualiser;            ///< The visualizer instance for rendering the model
-    ModelReader<Cell> modelReader;    ///< The reader for loading and managing model data
-    ContiguousGrid<Cell, 2> p;        ///< Temporary contiguous 2D storage until std::mdspan is available in the toolchain
+    Visualizer visualiser;           ///< The visualizer instance for rendering the model
+    ModelReader<Cell> modelReader;   ///< The reader for loading and managing model data
+    ContiguousGrid<Cell> p;          ///< Temporary contiguous grid storage with a default single layer until std::mdspan is available
 };

--- a/visualiserProxy/SceneWidgetVisualizerProxy.h
+++ b/visualiserProxy/SceneWidgetVisualizerProxy.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include "ISceneWidgetVisualizer.h"
 #include "data/ModelReader.hpp"
+#include "visualiserProxy/ContiguousGrid.h"
 #include "visualiser/Visualizer.hpp"
 
 struct Line;
@@ -53,20 +54,17 @@ public:
 
     /** @brief Initializes the internal matrix with the specified dimensions.
      *
-     * This method resizes the internal 2D vector to match the given dimensions,
-     * creating a grid of default-constructed Cell objects.
+     * This method resizes the internal contiguous storage to match the given
+     * dimensions, creating a grid of default-constructed Cell objects.
      *
      * @param dimX The width of the grid (number of columns)
      * @param dimY The height of the grid (number of rows)
      *
-     * @note The dimensions must be positive integers. The method will create a grid with dimY rows and dimX columns. */
+     * @note The dimensions must be positive integers. The method will create a
+     *       grid with dimY rows and dimX columns. */
     void initMatrix(int dimX, int dimY) override
     {
-        p.resize(dimY);
-        for (int i = 0; i < dimY; i++)
-        {
-            p[i].resize(dimX);
-        }
+        p.resize(dimY, dimX);
     }
 
     void prepareStage(int nNodeX, int nNodeY, int nNodeZ = 1) override
@@ -159,5 +157,5 @@ private:
 
     Visualizer visualiser;            ///< The visualizer instance for rendering the model
     ModelReader<Cell> modelReader;    ///< The reader for loading and managing model data
-    std::vector<std::vector<Cell>> p; ///< 2D vector storing the cell data
+    ContiguousGrid<Cell, 2> p;        ///< Temporary contiguous 2D storage until std::mdspan is available in the toolchain
 };


### PR DESCRIPTION
**Title**  
Refactor cell grid storage to contiguous memory with 2D/3D indexing support

**Description**  
This PR replaces the previous `std::vector<std::vector<Cell>>` storage used by `SceneWidgetVisualizerProxy` with a lightweight contiguous grid container based on `std::vector<Cell>`.

The main motivation is performance and memory behavior.

While nested containers can look clean and convenient, they come with costs that matter in C++:
- they require multiple allocations and deallocations instead of a single contiguous allocation,
- they add pointer indirection,
- they reduce spatial locality,
- and they increase the likelihood of cache misses during grid traversal.

For data structures that represent dense 2D or future 3D simulation space, contiguous storage is a better fit. It improves cache friendliness and makes sequential access patterns more efficient, which is exactly the kind of low-level control C++ is often chosen for.

To keep the calling code readable, the new container preserves multi-dimensional style access:
- current 2D usage remains natural with `grid[row][column]`,
- C++23 multidimensional indexing is also supported via `grid[row, column]`,
- and the same container is ready for future 3D scenarios through an optional third dimension with a default layer count of `1`.

**What changed**
- introduced a small header-only `ContiguousGrid` helper in `visualiserProxy`,
- replaced nested vector storage in `SceneWidgetVisualizerProxy`,
- kept the current 2D access style compatible,
- added support for future 3D-oriented indexing,
- documented the new public API with short Doxygen comments,
- marked the helper as a temporary solution until `std::mdspan` is reliably available in the toolchain.

**Why this matters**
This change is not just a structural cleanup. It is a performance-oriented refactor:
- fewer heap allocations,
- better memory locality,
- lower cache miss probability during iteration,
- and a simpler path toward efficient 3D support.
_____________________________
# Performance comare:
On my computer Claude generated test: 100x100x100:
```
Phase                     nested vvv    flat+mdspan   ratio
----------------------------------------------------------
1. Initialization          5.07ms         1.43ms      3.55x
2. Summation               0.40ms         0.40ms      1.01x
3. Deallocation            0.39ms         0.11ms      3.59x
----------------------------------------------------------
TOTAL                      5.86ms         1.93ms      3.03x
```
SciddicaT model has:
```
	number_of_columns=610
	number_of_rows=496
```
HydroCAL3D has:
```
	number_of_columns=883
	number_of_rows=638
	number_of_slices=5
```
