### PR TITLE
Add native 3D model visualization and cross-section views

### DIFF
--- a/.github/workflows/doxygen-pages.yml
+++ b/.github/workflows/doxygen-pages.yml
@@ -1,0 +1,154 @@
+name: Doxygen Documentation
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build-docs:
+    name: Build Doxygen documentation
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Doxygen and Graphviz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz
+
+      - name: Generate Doxygen configuration
+        run: |
+          mkdir -p build/docs
+
+          cat > build/Doxyfile.pages <<EOF
+          PROJECT_NAME           = "OOpenCal-Viewer"
+          PROJECT_BRIEF          = "OOpenCal-Viewer API documentation"
+          OUTPUT_DIRECTORY       = build/docs
+
+          INPUT                  = README.md \
+                                   core \
+                                   data \
+                                   config \
+                                   plugins \
+                                   visualiser \
+                                   visualiserProxy \
+                                   widgets \
+                                   doc \
+                                   examples
+          RECURSIVE              = YES
+          FILE_PATTERNS          = *.cpp *.cxx *.cc *.c *.h *.hpp *.hh *.ui *.qrc *.md
+          EXTENSION_MAPPING      = ui=C++ qrc=C++
+
+          EXCLUDE                = build \
+                                   build-codex \
+                                   .git \
+                                   .github \
+                                   .cache \
+                                   .qtcreator
+          EXCLUDE_PATTERNS       = *_autogen* \
+                                   moc_* \
+                                   ui_* \
+                                   qt_* \
+                                   *CMakeFiles* \
+                                   *_automoc.* \
+                                   *_autogen/* \
+                                   */moc_* \
+                                   */ui_* \
+                                   */qt_*
+
+          GENERATE_HTML          = YES
+          HTML_OUTPUT            = html
+          HTML_FILE_EXTENSION    = .html
+          GENERATE_TREEVIEW      = YES
+          DISABLE_INDEX          = NO
+
+          GENERATE_LATEX         = NO
+          GENERATE_XML           = NO
+          GENERATE_RTF           = NO
+          GENERATE_MAN           = NO
+
+          MARKDOWN_SUPPORT       = YES
+          USE_MDFILE_AS_MAINPAGE = README.md
+
+          ENABLE_PREPROCESSING   = YES
+          MACRO_EXPANSION        = YES
+          EXPAND_ONLY_PREDEF     = NO
+          PREDEFINED             = Q_OBJECT \
+                                   signals=public \
+                                   slots=public \
+                                   Q_SLOTS=public \
+                                   Q_SIGNALS=public \
+                                   emit= \
+                                   override= \
+                                   Q_DECLARE_PRIVATE(x)= \
+                                   QT_VERSION
+
+          HAVE_DOT               = YES
+          DOT_IMAGE_FORMAT       = svg
+          DOT_NUM_THREADS        = 0
+          CLASS_DIAGRAMS         = YES
+          CALL_GRAPH             = YES
+          CALLER_GRAPH           = YES
+          DOT_GRAPH_MAX_NODES    = 200
+
+          EXTRACT_ALL            = YES
+          EXTRACT_PRIVATE        = NO
+          EXTRACT_STATIC         = NO
+          FULL_PATH_NAMES        = YES
+          STRIP_FROM_PATH        = ${GITHUB_WORKSPACE}
+          WARNINGS               = YES
+          WARN_IF_UNDOCUMENTED   = NO
+          WARN_AS_ERROR          = NO
+          QUIET                  = NO
+          EOF
+
+      - name: Build HTML documentation
+        run: doxygen build/Doxyfile.pages
+
+      - name: Upload Doxygen HTML artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: doxygen-html
+          path: build/docs/html
+          if-no-files-found: error
+
+      - name: Configure GitHub Pages
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/develop')
+        uses: actions/configure-pages@v5
+
+      - name: Prepare GitHub Pages artifact
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/develop')
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/docs/html
+
+  deploy-docs:
+    name: Deploy documentation to GitHub Pages
+    needs: build-docs
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/develop')
+    runs-on: ubuntu-24.04
+
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -46,8 +46,9 @@ jobs:
         path: |
           ${{ runner.temp }}/vcpkg
           C:\vcpkg
-        key: vcpkg-vtk-${{ runner.os }}-x64-windows-v2
+        key: vcpkg-vtk-qttools-${{ runner.os }}-x64-windows-v3
         restore-keys: |
+          vcpkg-vtk-qttools-${{ runner.os }}-x64-windows-
           vcpkg-vtk-${{ runner.os }}-x64-windows-
 
     - name: Setup vcpkg
@@ -71,9 +72,10 @@ jobs:
           Write-Host "vcpkg already bootstrapped"
         }
         
-        # Install VTK with Qt and OpenGL support
-        Write-Host "Installing/updating VTK with Qt and OpenGL support..."
-        & "$vcpkg_exe" install vtk[qt,opengl]:x64-windows --recurse
+        # Install VTK with Qt and OpenGL support. qttools provides windeployqt.exe
+        # which is needed in the packaging step.
+        Write-Host "Installing/updating VTK with Qt/OpenGL support and Qt deployment tools..."
+        & "$vcpkg_exe" install vtk[qt,opengl]:x64-windows qttools:x64-windows --recurse
         
         # Make vcpkg root available for next steps
         Add-Content -Path $env:GITHUB_ENV -Value "VCPKG_ROOT=$vcpkg_root"
@@ -106,6 +108,7 @@ jobs:
       shell: pwsh
       run: |
         $vcpkg_root = "${{ runner.temp }}/vcpkg"
+        $vcpkg_exe = Join-Path $vcpkg_root "vcpkg.exe"
         $build_type = "${{ matrix.build_type }}"
         $exe_path = "build/$build_type/OOpenCal-Viewer.exe"
         $package_dir = "build/package/$build_type"
@@ -113,8 +116,20 @@ jobs:
         New-Item -ItemType Directory -Force -Path $package_dir | Out-Null
         Copy-Item $exe_path $package_dir -Force
         
-        $windeployqt = Get-ChildItem -Path "$vcpkg_root/installed/x64-windows" -Recurse -Filter windeployqt.exe | Select-Object -First 1
-        if (-not $windeployqt) { throw "windeployqt.exe not found under vcpkg." }
+        $installedRoot = Join-Path $vcpkg_root "installed/x64-windows"
+        $installedBin = Join-Path $installedRoot "bin"
+        $env:PATH = "$installedBin;$env:PATH"
+
+        $windeployqt = Get-ChildItem -Path $installedRoot -Recurse -Filter windeployqt.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+        if (-not $windeployqt) {
+          Write-Host "windeployqt.exe was not found under $installedRoot."
+          Write-Host "Installed Qt-related vcpkg packages:"
+          & "$vcpkg_exe" list | Select-String -Pattern "^(qt|vtk)" | ForEach-Object { Write-Host $_ }
+          Write-Host "Qt tool directories, if any:"
+          Get-ChildItem -Path $installedRoot -Directory -Recurse -ErrorAction SilentlyContinue | Where-Object { $_.FullName -match "tools.*Qt|qt" } | Select-Object -First 50 | ForEach-Object { Write-Host $_.FullName }
+          throw "windeployqt.exe not found under vcpkg. The qttools:x64-windows package is required for packaging."
+        }
+        Write-Host "Using windeployqt: $($windeployqt.FullName)"
         
         $deployArgs = @("--no-translations")
         if ($build_type -eq "Debug") { $deployArgs += "--debug" } else { $deployArgs += "--release" }

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -9,13 +9,13 @@ on:
 
 jobs:
   build-windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { build_type: "Release", generator: "Visual Studio 17 2022" }
+          - { build_type: "Release", generator: "Ninja Multi-Config" }
 
     steps:
     - name: Checkout repository
@@ -34,6 +34,11 @@ jobs:
       with:
         cmakeVersion: "~3.27"
         ninjaVersion: "^1.11"
+
+    - name: Setup MSVC
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
 
     - name: Cache vcpkg and packages
       uses: actions/cache@v4
@@ -84,15 +89,12 @@ jobs:
         Write-Host "Project root: $project_root"
         Write-Host "OOpenCAL parent (OOPENCAL_DIR): $oopencal_dir"
         
-        mkdir -p build
-        cd build
-        
-        cmake -G "${{ matrix.generator }}" `
+        cmake -S . -B build -G "${{ matrix.generator }}" `
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `
+          -DCMAKE_CONFIGURATION_TYPES=${{ matrix.build_type }} `
           -DCMAKE_TOOLCHAIN_FILE="$toolchain_file" `
           -DOOPENCAL_DIR="$oopencal_dir" `
-          -DUSE_QT6=ON `
-          ..
+          -DUSE_QT6=ON
 
     - name: Build project
       shell: pwsh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,8 @@ find_package(VTK QUIET COMPONENTS
     RenderingFreeType
     RenderingGL2PSOpenGL2
     RenderingOpenGL2
+    RenderingVolume
+    RenderingVolumeOpenGL2
     IOXML
     IOOggTheora
     GUISupportQt
@@ -504,7 +506,7 @@ endif()
 
 vtk_module_autoinit(
     TARGETS ${PROJECT_NAME}
-    MODULES VTK::GUISupportQt VTK::IOLegacy
+    MODULES VTK::GUISupportQt VTK::IOLegacy VTK::RenderingVolumeOpenGL2
 )
 
 # ============================================

--- a/core/types.h
+++ b/core/types.h
@@ -56,3 +56,34 @@ struct ColumnAndRow
         return row;
     }
 };
+
+/** @struct ColumnRowSlice
+ * @brief Represents dimensions or coordinates in a three-dimensional grid. */
+struct ColumnRowSlice
+{
+    using CoordinateType = int;
+
+    CoordinateType column;
+    CoordinateType row;
+    CoordinateType slice;
+
+    static ColumnRowSlice xyz(CoordinateType x, CoordinateType y, CoordinateType z)
+    {
+        return ColumnRowSlice{ .column = x, .row = y, .slice = z };
+    }
+
+    auto x() const
+    {
+        return column;
+    }
+
+    auto y() const
+    {
+        return row;
+    }
+
+    auto z() const
+    {
+        return slice;
+    }
+};

--- a/core/types.h
+++ b/core/types.h
@@ -22,6 +22,15 @@ using NodeIndex = unsigned;
  * @note: The type should be (according to standard) `std::streampos`, but the type can not be used in streams */
 using FilePosition = long long;
 
+/** @enum GridSliceAxis
+ * @brief Axis held constant when exposing a 2D view of 3D data. */
+enum class GridSliceAxis
+{
+    X,
+    Y,
+    Z
+};
+
 /** @struct ColumnAndRow
  * @brief Represents a 2D coordinate system using column and row indices.
  *

--- a/data/ModelReader.cpp
+++ b/data/ModelReader.cpp
@@ -3,11 +3,16 @@
 
 ColumnAndRow ReaderHelpers::getColumnAndRowFromLine(const std::string& line)
 {
-    /// input format: "C-R" for 2D or "C-R-S" for 3D where C, R, and S are numbers
-    /// For 3D models, we only extract C and R (columns and rows), ignoring slices
+    const auto dimensions = getDimensionsFromLine(line);
+    return ColumnAndRow::xy(dimensions.column, dimensions.row);
+}
+
+ColumnRowSlice ReaderHelpers::getDimensionsFromLine(const std::string& line)
+{
+    /// Input format: "C-R" for 2D or "C-R-S" for 3D.
     if (line.empty())
     {
-        throw std::invalid_argument("Line is empty, but it should contain columns and row!");
+        throw std::invalid_argument("Line is empty, but it should contain grid dimensions!");
     }
 
     const auto firstDelimiterPos = line.find('-');
@@ -16,25 +21,19 @@ ColumnAndRow ReaderHelpers::getColumnAndRowFromLine(const std::string& line)
         throw std::runtime_error("No delimiter '-' found in the line: >" + line + "<");
     }
 
-    const auto x = std::stoi(line.substr(0, firstDelimiterPos));
-    
-    // Find second delimiter to check if this is 3D format (C-R-S)
+    const auto columns = std::stoi(line.substr(0, firstDelimiterPos));
     const auto secondDelimiterPos = line.find('-', firstDelimiterPos + 1);
-    
-    int y;
+
     if (secondDelimiterPos != std::string::npos)
     {
-        // 3D format: C-R-S, extract R from between first and second delimiter
-        y = std::stoi(line.substr(firstDelimiterPos + 1, secondDelimiterPos - firstDelimiterPos - 1));
-        // Note: We ignore the slice count (S) here as it's handled separately
+        const auto rows = std::stoi(line.substr(firstDelimiterPos + 1,
+                                                secondDelimiterPos - firstDelimiterPos - 1));
+        const auto slices = std::stoi(line.substr(secondDelimiterPos + 1));
+        return ColumnRowSlice::xyz(columns, rows, slices);
     }
-    else
-    {
-        // 2D format: C-R
-        y = std::stoi(line.substr(firstDelimiterPos + 1));
-    }
-    
-    return ColumnAndRow::xy(x, y);
+
+    const auto rows = std::stoi(line.substr(firstDelimiterPos + 1));
+    return ColumnRowSlice::xyz(columns, rows, 1);
 }
 
 ColumnAndRow ReaderHelpers::calculateXYOffsetForNode(NodeIndex node,
@@ -59,4 +58,43 @@ ColumnAndRow ReaderHelpers::calculateXYOffsetForNode(NodeIndex node,
         }
     }
     return ColumnAndRow::xy(offsetX, offsetY);
+}
+
+ColumnRowSlice ReaderHelpers::calculateXYZOffsetForNode(
+    NodeIndex node,
+    NodeIndex nNodeX,
+    NodeIndex nNodeY,
+    NodeIndex nNodeZ,
+    const std::vector<ColumnRowSlice>& dimensions)
+{
+    const auto totalNodes = nNodeX * nNodeY * nNodeZ;
+    if (nNodeX == 0 || nNodeY == 0 || nNodeZ == 0 ||
+        node >= totalNodes || dimensions.size() < totalNodes)
+    {
+        throw std::invalid_argument("Invalid node grid while calculating a 3D offset");
+    }
+
+    const NodeIndex nodeX = node % nNodeX;
+    const NodeIndex nodeY = (node / nNodeX) % nNodeY;
+    const NodeIndex nodeZ = node / (nNodeX * nNodeY);
+
+    int offsetX = 0;
+    int offsetY = 0;
+    int offsetZ = 0;
+
+    auto nodeIndex = [=](NodeIndex x, NodeIndex y, NodeIndex z)
+    {
+        return z * nNodeX * nNodeY + y * nNodeX + x;
+    };
+
+    for (NodeIndex x = 0; x < nodeX; ++x)
+        offsetX += dimensions[nodeIndex(x, nodeY, nodeZ)].column;
+
+    for (NodeIndex y = 0; y < nodeY; ++y)
+        offsetY += dimensions[nodeIndex(nodeX, y, nodeZ)].row;
+
+    for (NodeIndex z = 0; z < nodeZ; ++z)
+        offsetZ += dimensions[nodeIndex(nodeX, nodeY, z)].slice;
+
+    return ColumnRowSlice::xyz(offsetX, offsetY, offsetZ);
 }

--- a/data/ModelReader.hpp
+++ b/data/ModelReader.hpp
@@ -43,7 +43,7 @@ public:
     struct StepOffsetInfo
     {
         FilePosition position;
-        std::optional<ColumnAndRow> sceneSize;
+        std::optional<ColumnRowSlice> sceneSize;
     };
 
 private:
@@ -145,16 +145,17 @@ private:
     [[nodiscard]] std::ifstream readColumnAndRowForStepFromFileReturningStream(StepIndex step,
                                                                                const std::string& fileName,
                                                                                NodeIndex node,
-                                                                               ColumnAndRow& columnAndRow,
+                                                                               ColumnRowSlice& dimensions,
                                                                                bool isBinary = false);
 
-    [[nodiscard]] ColumnAndRow readColumnAndRowForStepFromFile(StepIndex step, const std::string& fileName, NodeIndex node, bool isBinary = false);
+    [[nodiscard]] ColumnRowSlice readDimensionsForStepFromFile(StepIndex step, const std::string& fileName, NodeIndex node, bool isBinary = false);
 
-    std::vector<ColumnAndRow> giveMeLocalColsAndRowsForAllSteps(StepIndex step,
-                                                                NodeIndex nNodeX,
-                                                                NodeIndex nNodeY,
-                                                                const std::string& fileName,
-                                                                bool isBinary = false);
+    std::vector<ColumnRowSlice> localDimensionsForAllNodes(StepIndex step,
+                                                           NodeIndex nNodeX,
+                                                           NodeIndex nNodeY,
+                                                           NodeIndex nNodeZ,
+                                                           const std::string& fileName,
+                                                           bool isBinary = false);
 };
 
 /////////////////////////////
@@ -174,22 +175,30 @@ namespace ReaderHelpers /// functions which are not templates
 ColumnAndRow getColumnAndRowFromLine(const std::string& line);
 
 ColumnAndRow calculateXYOffsetForNode(NodeIndex node, NodeIndex nNodeX, NodeIndex nNodeY, const std::vector<ColumnAndRow>& columnsAndRows);
+
+ColumnRowSlice getDimensionsFromLine(const std::string& line);
+
+ColumnRowSlice calculateXYZOffsetForNode(NodeIndex node,
+                                         NodeIndex nNodeX,
+                                         NodeIndex nNodeY,
+                                         NodeIndex nNodeZ,
+                                         const std::vector<ColumnRowSlice>& dimensions);
 } // namespace ReaderHelpers
 /////////////////////////////
 
 template<CellLike Cell>
-ColumnAndRow ModelReader<Cell>::readColumnAndRowForStepFromFile(StepIndex step, const std::string& fileName, NodeIndex node, bool isBinary)
+ColumnRowSlice ModelReader<Cell>::readDimensionsForStepFromFile(StepIndex step, const std::string& fileName, NodeIndex node, bool isBinary)
 {
-    ColumnAndRow columnAndRow;
-    std::ifstream file [[maybe_unused]] = readColumnAndRowForStepFromFileReturningStream(step, fileName, node, columnAndRow, isBinary);
-    return columnAndRow;
+    ColumnRowSlice dimensions;
+    std::ifstream file [[maybe_unused]] = readColumnAndRowForStepFromFileReturningStream(step, fileName, node, dimensions, isBinary);
+    return dimensions;
 }
 
 template<CellLike Cell>
 std::ifstream ModelReader<Cell>::readColumnAndRowForStepFromFileReturningStream(StepIndex step,
                                                                                 const std::string& fileName,
                                                                                 NodeIndex node,
-                                                                                ColumnAndRow& columnAndRow,
+                                                                                ColumnRowSlice& dimensions,
                                                                                 bool isBinary)
 {
     const auto fileNameTmp = ReaderHelpers::giveMeFileName(fileName, node, isBinary);
@@ -216,7 +225,7 @@ std::ifstream ModelReader<Cell>::readColumnAndRowForStepFromFileReturningStream(
         const auto& stepMap = nodeStepOffsets[node];
         if (auto it = stepMap.find(step); it != stepMap.end() && it->second.sceneSize.has_value())
         {
-            columnAndRow = it->second.sceneSize.value();
+            dimensions = it->second.sceneSize.value();
         }
         else
         {
@@ -232,7 +241,7 @@ std::ifstream ModelReader<Cell>::readColumnAndRowForStepFromFileReturningStream(
             throw std::runtime_error(std::format("Failed to read line from '{}' at position {}", fileNameTmp, fPos));
         }
 
-        columnAndRow = ReaderHelpers::getColumnAndRowFromLine(line);
+        dimensions = ReaderHelpers::getDimensionsFromLine(line);
     }
 
     return file;
@@ -242,8 +251,6 @@ template<CellLike Cell>
 template<class Matrix>
 void ModelReader<Cell>::readStageStateFromFilesForStep(Matrix& m, SettingParameter* sp, Line* lines)
 {
-    // Create a performance session that tracks this operation
-    // Note: Session is destroyed at the end of the scope, triggering metrics recording
     PerformanceSession perfSession("readStageStateFromFilesForStep", 
                                    static_cast<uint32_t>(sp->numberOfColumnX),
                                    static_cast<uint32_t>(sp->numberOfRowsY),
@@ -252,55 +259,69 @@ void ModelReader<Cell>::readStageStateFromFilesForStep(Matrix& m, SettingParamet
     perfSession.setStepNumber(sp->step);
     perfSession.setCategory(PerformanceMetrics::MetricsCategory::DataLoading);
 
-    const auto totalNodes = sp->nNodeX * sp->nNodeY;
+    const auto totalNodes = sp->nNodeX * sp->nNodeY * sp->nNodeZ;
     const bool isBinary = (sp->readMode == "binary");
-    const auto columnsAndRows = giveMeLocalColsAndRowsForAllSteps(sp->step, sp->nNodeX, sp->nNodeY, sp->outputFileName, isBinary);
+    const auto localDimensions = localDimensionsForAllNodes(sp->step,
+                                                            sp->nNodeX,
+                                                            sp->nNodeY,
+                                                            sp->nNodeZ,
+                                                            sp->outputFileName,
+                                                            isBinary);
 
-    // Calculate total cells that will be read in this call
     size_t totalCellsForThisCall = 0;
-    for (const auto& colRow : columnsAndRows)
+    for (const auto& dimensions : localDimensions)
     {
-        totalCellsForThisCall += static_cast<size_t>(colRow.column) * colRow.row;
+        totalCellsForThisCall += static_cast<size_t>(dimensions.column) *
+                                 dimensions.row *
+                                 dimensions.slice;
     }
-
     perfSession.recordReadCall(totalCellsForThisCall);
 
-    /// Lambda responsible for reading and processing a single node's file
     auto processNode = [&, this](NodeIndex node)
     {
-        const auto offsetXY = ReaderHelpers::calculateXYOffsetForNode(node, sp->nNodeX, sp->nNodeY, columnsAndRows);
+        const auto offset = ReaderHelpers::calculateXYZOffsetForNode(node,
+                                                                     sp->nNodeX,
+                                                                     sp->nNodeY,
+                                                                     sp->nNodeZ,
+                                                                     localDimensions);
 
-        ColumnAndRow columnAndRow;
-        std::ifstream fp = readColumnAndRowForStepFromFileReturningStream(sp->step, sp->outputFileName, node, columnAndRow, isBinary);
+        ColumnRowSlice dimensions;
+        std::ifstream fp = readColumnAndRowForStepFromFileReturningStream(sp->step,
+                                                                          sp->outputFileName,
+                                                                          node,
+                                                                          dimensions,
+                                                                          isBinary);
         if (! fp)
             throw std::runtime_error("Cannot open file for node " + std::to_string(node));
 
-        // Clamp coordinates to matrix bounds
         const int maxX = static_cast<int>(m[0].size()) - 1;
         const int maxY = static_cast<int>(m.size()) - 1;
-        
-        const int x1 = std::min(offsetXY.x(), maxX);
-        const int y1 = std::min(offsetXY.y(), maxY);
-        const int x2 = std::min(offsetXY.x() + columnAndRow.column, maxX + 1);
-        const int y2 = std::min(offsetXY.y() + columnAndRow.row, maxY + 1);
-        
-        // Define boundary lines for the node (bottom and left edges)
+
+        const int x1 = std::min(offset.x(), maxX);
+        const int y1 = std::min(offset.y(), maxY);
+        const int x2 = std::min(offset.x() + dimensions.column, maxX + 1);
+        const int y2 = std::min(offset.y() + dimensions.row, maxY + 1);
+
         lines[node * 2] = Line(x1, y1, x2, y1);
         lines[node * 2 + 1] = Line(x1, y1, x1, y2);
 
-        // Add top edge line for nodes in the last row (highest y)
-        const NodeIndex nodeRow = node / sp->nNodeX;
-        if (nodeRow == sp->nNodeY - 1) // Top row
+        const NodeIndex nodeRow = (node / sp->nNodeX) % sp->nNodeY;
+        const NodeIndex nodeSlice = node / (sp->nNodeX * sp->nNodeY);
+        if (nodeRow == sp->nNodeY - 1)
         {
-            const int topLineIndex = 2 * totalNodes + (node % sp->nNodeX);
+            const int topLineIndex = 2 * totalNodes +
+                                     nodeSlice * sp->nNodeX +
+                                     (node % sp->nNodeX);
             lines[topLineIndex] = Line(x1, y2, x2, y2);
         }
 
-        // Add right edge line for nodes in the last column (highest x)
         const NodeIndex nodeCol = node % sp->nNodeX;
-        if (nodeCol == sp->nNodeX - 1) // Rightmost column
+        if (nodeCol == sp->nNodeX - 1)
         {
-            const int rightLineIndex = 2 * totalNodes + sp->nNodeX + nodeRow;
+            const int rightLineIndex = 2 * totalNodes +
+                                       sp->nNodeX * sp->nNodeZ +
+                                       nodeSlice * sp->nNodeY +
+                                       nodeRow;
             lines[rightLineIndex] = Line(x2, y1, x2, y2);
         }
 
@@ -308,8 +329,9 @@ void ModelReader<Cell>::readStageStateFromFilesForStep(Matrix& m, SettingParamet
 
         if (isBinary)
         {
-            // Binary mode: read raw cell data
-            const size_t cellCount = columnAndRow.column * columnAndRow.row;
+            const size_t cellCount = static_cast<size_t>(dimensions.column) *
+                                     dimensions.row *
+                                     dimensions.slice;
             const size_t cellSize = sizeof(Cell);
             const size_t totalBytes = cellCount * cellSize;
 
@@ -321,99 +343,106 @@ void ModelReader<Cell>::readStageStateFromFilesForStep(Matrix& m, SettingParamet
                 throw std::runtime_error(std::format("Failed to read {} bytes from binary file for node {}", totalBytes, node));
             }
 
-            // Parse binary data and fill matrix
-            for (int row = 0; row < columnAndRow.row; ++row)
+            for (int slice = 0; slice < dimensions.slice; ++slice)
             {
-                const int matrixRow = row + offsetXY.y();
-                if (matrixRow >= static_cast<int>(m.size()))
-                    continue; // Skip rows that are out of bounds
-                    
-                for (int col = 0; col < columnAndRow.column; ++col)
+                const int matrixSlice = slice + offset.z();
+                if (matrixSlice >= static_cast<int>(m.layerCount()))
+                    continue;
+
+                for (int row = 0; row < dimensions.row; ++row)
                 {
-                    const int matrixCol = col + offsetXY.x();
-                    if (matrixCol >= static_cast<int>(m[matrixRow].size()))
-                        continue; // Skip columns that are out of bounds
+                    const int matrixRow = row + offset.y();
+                    if (matrixRow >= static_cast<int>(m.size()))
+                        continue;
 
-                    if (! localStartStepDone) [[unlikely]]
+                    for (int col = 0; col < dimensions.column; ++col)
                     {
-                        m[matrixRow][matrixCol].startStep(sp->step);
-                        localStartStepDone = true;
+                        const int matrixCol = col + offset.x();
+                        if (matrixCol >= static_cast<int>(m[matrixRow].size()))
+                            continue;
+
+                        if (! localStartStepDone) [[unlikely]]
+                        {
+                            m[matrixRow, matrixCol, matrixSlice].startStep(sp->step);
+                            localStartStepDone = true;
+                        }
+
+                        const size_t cellIndex =
+                            (static_cast<size_t>(slice) * dimensions.row + row) *
+                            dimensions.column +
+                            col;
+                        const char* cellData = buffer.data() + (cellIndex * cellSize);
+
+                        Cell tempCell;
+                        std::memcpy(&tempCell, cellData, cellSize); /// @note This erases the temporary object's vtable; assignment copies the cell state.
+                        m[matrixRow, matrixCol, matrixSlice] = tempCell;
                     }
-
-                    const size_t cellIndex = row * columnAndRow.column + col;
-                    const char* cellData = buffer.data() + (cellIndex * cellSize);
-
-                    // Create a temporary cell from binary data and copy to matrix
-                    Cell tempCell;
-                    std::memcpy(&tempCell, cellData, cellSize); /// @note This is erasing vtable, so don't use the object polimorphic way
-                    m[matrixRow][matrixCol] = tempCell;
                 }
             }
         }
         else
         {
-            // Text mode: read and parse text data (original behavior)
-            // Use a thread-local buffer for faster reading
             static thread_local char fileBuffer[1 << 16];
             fp.rdbuf()->pubsetbuf(fileBuffer, sizeof(fileBuffer));
 
-            // Reserve a large line buffer to minimize reallocations
             constexpr std::size_t numbersPerLine = 10'000;
             const std::size_t lineBufferSize = (std::log10(UINT_MAX) + 2) * numbersPerLine;
             std::string line;
             line.reserve(lineBufferSize);
 
-            // Process each line (row) from the node's file
-            for (int row = 0; row < columnAndRow.row; ++row)
+            // Each slice is serialized as `rows` consecutive text lines.
+            for (int slice = 0; slice < dimensions.slice; ++slice)
             {
-                const int matrixRow = row + offsetXY.y();
-                if (matrixRow >= static_cast<int>(m.size()))
+                const int matrixSlice = slice + offset.z();
+
+                for (int row = 0; row < dimensions.row; ++row)
                 {
-                    // Skip reading this line from file but don't process it
                     if (! std::getline(fp, line))
                     {
                         const auto fileNameTmp = ReaderHelpers::giveMeFileName(sp->outputFileName, node, isBinary);
                         throw std::runtime_error("Error reading entire line from " + fileNameTmp);
                     }
-                    continue; // Skip this row - it's out of bounds
-                }
-                    
-                if (! std::getline(fp, line))
-                {
-                    const auto fileNameTmp = ReaderHelpers::giveMeFileName(sp->outputFileName, node, isBinary);
-                    throw std::runtime_error("Error reading entire line from " + fileNameTmp);
-                }
 
-                // Replace spaces with '\0' to tokenize more efficiently
-                std::replace(line.begin(), line.end(), ' ', '\0');
-
-                // Tokenize and fill the corresponding part of the matrix
-                char* currentTokenPtr = line.data();
-                for (int col = 0; col < columnAndRow.column && *currentTokenPtr; ++col)
-                {
-                    const int matrixCol = col + offsetXY.x();
-                    if (matrixCol >= static_cast<int>(m[matrixRow].size()))
-                        continue; // Skip this column - it's out of bounds
-
-                    if (! localStartStepDone) [[unlikely]]
+                    const int matrixRow = row + offset.y();
+                    if (matrixSlice >= static_cast<int>(m.layerCount()) ||
+                        matrixRow >= static_cast<int>(m.size()))
                     {
-                        m[matrixRow][matrixCol].startStep(sp->step);
-                        localStartStepDone = true;
+                        continue;
                     }
 
-                    /// composeElement() may add extra '\0', so we need extra variable to jump to next position
-                    char* nextTokenPtr = std::find(currentTokenPtr, line.data() + line.size(), '\0');
-                    ++nextTokenPtr; // skip '\0'
+                    char* cursor = line.data();
+                    char* const end = line.data() + line.size();
 
-                    m[matrixRow][matrixCol].composeElement(currentTokenPtr);
+                    for (int col = 0; col < dimensions.column; ++col)
+                    {
+                        while (cursor < end && *cursor == ' ')
+                            ++cursor;
+                        if (cursor >= end)
+                            break;
 
-                    currentTokenPtr = nextTokenPtr;
+                        char* const token = cursor;
+                        while (cursor < end && *cursor != ' ')
+                            ++cursor;
+                        if (cursor < end)
+                            *cursor++ = '\0';
+
+                        const int matrixCol = col + offset.x();
+                        if (matrixCol >= static_cast<int>(m[matrixRow].size()))
+                            continue;
+
+                        if (! localStartStepDone) [[unlikely]]
+                        {
+                            m[matrixRow, matrixCol, matrixSlice].startStep(sp->step);
+                            localStartStepDone = true;
+                        }
+
+                        m[matrixRow, matrixCol, matrixSlice].composeElement(token);
+                    }
                 }
             }
         }
     };
 
-    /// Launch async tasks — one per node
     std::vector<std::future<void>> futures;
     futures.reserve(totalNodes);
 
@@ -426,31 +455,29 @@ void ModelReader<Cell>::readStageStateFromFilesForStep(Matrix& m, SettingParamet
                                      }));
     }
 
-    // Wait for all async tasks to complete
     std::ranges::for_each(futures,
                           [](std::future<void>& f)
                           {
                               f.get();
                           });
-    // PerformanceSession destructor will record metrics automatically
 }
 
 template<CellLike Cell>
-std::vector<ColumnAndRow> ModelReader<Cell>::giveMeLocalColsAndRowsForAllSteps(StepIndex step,
-                                                                               NodeIndex nNodeX,
-                                                                               NodeIndex nNodeY,
-                                                                               const std::string& fileName,
-                                                                               bool isBinary)
+std::vector<ColumnRowSlice> ModelReader<Cell>::localDimensionsForAllNodes(StepIndex step,
+                                                                         NodeIndex nNodeX,
+                                                                         NodeIndex nNodeY,
+                                                                         NodeIndex nNodeZ,
+                                                                         const std::string& fileName,
+                                                                         bool isBinary)
 {
-    const auto nodesCount = nNodeX * nNodeY;
-    std::vector<ColumnAndRow> allColumnsAndRows(nodesCount);
-    allColumnsAndRows.resize(nodesCount);
+    const auto nodesCount = nNodeX * nNodeY * nNodeZ;
+    std::vector<ColumnRowSlice> allDimensions(nodesCount);
 
     for (NodeIndex node = 0; node < nodesCount; node++)
     {
-        allColumnsAndRows[node] = readColumnAndRowForStepFromFile(step, fileName, node, isBinary);
+        allDimensions[node] = readDimensionsForStepFromFile(step, fileName, node, isBinary);
     }
-    return allColumnsAndRows;
+    return allDimensions;
 }
 
 template<CellLike Cell>
@@ -483,17 +510,18 @@ void ModelReader<Cell>::readStepsOffsetsForAllNodesFromFiles(NodeIndex nNodeX, N
 
             StepOffsetInfo info{position, std::nullopt};
 
-            // Check if we have the optional "(columns-rows)" part
+            // Check if we have the optional "(columns-rows[-slices])" part
             std::string rangePart;
             if (iss >> rangePart)
             {
-                std::regex rangeRegex(R"(\((\d+)-(\d+)\))");
+                std::regex rangeRegex(R"(\((\d+)-(\d+)(?:-(\d+))?\))");
                 std::smatch match;
                 if (std::regex_match(rangePart, match, rangeRegex))
                 {
                     const int columnCount = std::stoi(match[1].str());
                     const int rowsCount = std::stoi(match[2].str());
-                    info.sceneSize = ColumnAndRow{.column = columnCount, .row = rowsCount};
+                    const int slicesCount = match[3].matched ? std::stoi(match[3].str()) : 1;
+                    info.sceneSize = ColumnRowSlice::xyz(columnCount, rowsCount, slicesCount);
                 }
                 else
                 {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <source_location>
 #include <algorithm>
+#include <cmath>
 #include <QCommonStyle>
 #include <QSettings>
 #include <QDebug>
@@ -47,8 +48,9 @@
 namespace
 {
 constexpr StepIndex FIRST_STEP_NUMBER = 0;
-constexpr int NATIVE_3D_DEFAULT_PITCH = 30;
+constexpr int NATIVE_3D_DEFAULT_PITCH = 0;
 constexpr int NATIVE_3D_DEFAULT_YAW = 0;
+constexpr int NATIVE_3D_DEFAULT_ROLL = 30;
 
 inline std::string sourceFileParentDirectoryAbsolutePath(const std::source_location& location = std::source_location::current())
 {
@@ -1472,6 +1474,9 @@ void MainWindow::onResetCameraRequested()
     const int defaultYaw = ui->sceneWidget->isNative3DModel()
                                ? NATIVE_3D_DEFAULT_YAW
                                : 0;
+    const int defaultRoll = ui->sceneWidget->isNative3DModel()
+                                ? NATIVE_3D_DEFAULT_ROLL
+                                : 0;
 
     // Block the controls while applying one coherent camera preset.
     QSignalBlocker rollBlocker(ui->rollSlider);
@@ -1481,26 +1486,22 @@ void MainWindow::onResetCameraRequested()
     QSignalBlocker pitchSpinBoxBlocker(ui->pitchSpinBox);
     QSignalBlocker yawSpinBoxBlocker(ui->yawSpinBox);
 
-    // Azimuth/elevation are not represented by GUI controls, so they must stay
-    // neutral. The native-3D oblique preset uses visible Pitch/Yaw instead.
-    ui->sceneWidget->setCameraAzimuth(0);
-    ui->sceneWidget->setCameraElevation(0);
-    ui->sceneWidget->setCameraRoll(0);
+    ui->sceneWidget->setCameraRoll(defaultRoll);
     ui->sceneWidget->setCameraPitch(defaultPitch);
     ui->sceneWidget->setCameraYaw(defaultYaw);
 
     // Reset zoom to default level
     ui->sceneWidget->resetCameraZoom();
 
-    ui->rollSlider->setValue(0);
-    ui->rollSpinBox->setValue(0);
+    ui->rollSlider->setValue(defaultRoll);
+    ui->rollSpinBox->setValue(defaultRoll);
     ui->pitchSlider->setValue(defaultPitch);
     ui->pitchSpinBox->setValue(defaultPitch);
     ui->yawSlider->setValue(defaultYaw);
     ui->yawSpinBox->setValue(defaultYaw);
 }
 
-void MainWindow::onCameraOrientationChanged(double azimuth, double elevation, double roll, double pitch, double yaw)
+void MainWindow::onCameraOrientationChanged(double roll, double pitch, double yaw)
 {
     // Block signals to avoid circular updates
     QSignalBlocker rollBlocker(ui->rollSlider);
@@ -1510,12 +1511,16 @@ void MainWindow::onCameraOrientationChanged(double azimuth, double elevation, do
     QSignalBlocker pitchSpinBoxBlocker(ui->pitchSpinBox);
     QSignalBlocker yawSpinBoxBlocker(ui->yawSpinBox);
 
-    ui->rollSlider->setValue(static_cast<int>(roll));
-    ui->rollSpinBox->setValue(static_cast<int>(roll));
-    ui->pitchSlider->setValue(static_cast<int>(pitch));
-    ui->pitchSpinBox->setValue(static_cast<int>(pitch));
-    ui->yawSlider->setValue(static_cast<int>(yaw));
-    ui->yawSpinBox->setValue(static_cast<int>(yaw));
+    const int rollDegrees = static_cast<int>(std::lround(roll));
+    const int pitchDegrees = static_cast<int>(std::lround(pitch));
+    const int yawDegrees = static_cast<int>(std::lround(yaw));
+
+    ui->rollSlider->setValue(rollDegrees);
+    ui->rollSpinBox->setValue(rollDegrees);
+    ui->pitchSlider->setValue(pitchDegrees);
+    ui->pitchSpinBox->setValue(pitchDegrees);
+    ui->yawSlider->setValue(yawDegrees);
+    ui->yawSpinBox->setValue(yawDegrees);
 }
 
 // ============================================================================

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -956,6 +956,8 @@ void MainWindow::openConfigurationFile(const QString& configFileName, std::share
             updateSubstateDockeWidget();
         }
 
+        synchronizeViewModeWithLoadedModel();
+
         // Initialize reduction manager for this configuration
         // If config is provided, use it; otherwise read from file
         initializeReductionManager(configFileName, optionalConfig);
@@ -1330,6 +1332,15 @@ void MainWindow::createViewModeActionGroup()
 
 void MainWindow::on2DModeRequested()
 {
+    if (ui->sceneWidget->isNative3DModel())
+    {
+        QSignalBlocker blocker2D(ui->action2DMode);
+        QSignalBlocker blocker3D(ui->action3DMode);
+        ui->action2DMode->setChecked(false);
+        ui->action3DMode->setChecked(true);
+        return;
+    }
+
     ui->sceneWidget->setViewMode2D();
     updateCameraControlsVisibility();
 
@@ -1363,6 +1374,28 @@ void MainWindow::on3DModeRequested()
     syncFlatSceneBackgroundCheckbox();
 
     std::cout << "[DEBUG] View Mode Changed: Switched to 3D mode.\nYou can now rotate the camera using mouse or the sliders below." << std::endl;
+}
+
+void MainWindow::synchronizeViewModeWithLoadedModel()
+{
+    const bool native3D = ui->sceneWidget->isNative3DModel();
+
+    // A native 3D volume has no meaningful flat-view representation.
+    // A 2D model still keeps 3D available for "substate as altitude".
+    ui->action2DMode->setEnabled(!native3D);
+    ui->action3DMode->setEnabled(true);
+
+    if (native3D)
+    {
+        on3DModeRequested();
+        // Start from an oblique angle so a sphere/volume is visibly three-dimensional
+        // immediately, instead of presenting only its top-down circular silhouette.
+        ui->sceneWidget->setCameraAzimuth(-35.0);
+        ui->sceneWidget->setCameraElevation(25.0);
+        ui->sceneWidget->resetCameraZoom();
+    }
+    else
+        on2DModeRequested();
 }
 
 void MainWindow::onGridLinesToggled(bool checked)
@@ -1763,8 +1796,8 @@ void MainWindow::setWidgetsEnabledState(bool enabled)
     ui->actionExport_Video->setEnabled(enabled);
     ui->actionReloadData->setEnabled(enabled);
 
-    // View mode actions should always be enabled
-    ui->action2DMode->setEnabled(true);
+    // Native 3D models cannot be flattened; 2D models retain optional 3D substates.
+    ui->action2DMode->setEnabled(!ui->sceneWidget->isNative3DModel());
     ui->action3DMode->setEnabled(true);
 
     changeWhichButtonsAreEnabled();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -47,6 +47,8 @@
 namespace
 {
 constexpr StepIndex FIRST_STEP_NUMBER = 0;
+constexpr int NATIVE_3D_DEFAULT_PITCH = 30;
+constexpr int NATIVE_3D_DEFAULT_YAW = 0;
 
 inline std::string sourceFileParentDirectoryAbsolutePath(const std::source_location& location = std::source_location::current())
 {
@@ -251,7 +253,7 @@ void MainWindow::availableStepsLoadedFromConfigFile(std::vector<StepIndex> avail
 {
     // Store the list of available steps for intelligent step navigation
     this->availableSteps = availableSteps;
-    
+
     // Update button states based on available steps
     changeWhichButtonsAreEnabled();
     
@@ -1386,14 +1388,7 @@ void MainWindow::synchronizeViewModeWithLoadedModel()
     ui->action3DMode->setEnabled(true);
 
     if (native3D)
-    {
         on3DModeRequested();
-        // Start from an oblique angle so a sphere/volume is visibly three-dimensional
-        // immediately, instead of presenting only its top-down circular silhouette.
-        ui->sceneWidget->setCameraAzimuth(-35.0);
-        ui->sceneWidget->setCameraElevation(25.0);
-        ui->sceneWidget->resetCameraZoom();
-    }
     else
         on2DModeRequested();
 }
@@ -1471,30 +1466,38 @@ void MainWindow::onYawChanged(int value)
 
 void MainWindow::onResetCameraRequested()
 {
-    // Reset all camera angles to initial state
-    ui->sceneWidget->setCameraAzimuth(0);
-    ui->sceneWidget->setCameraElevation(0);
-    ui->sceneWidget->setCameraRoll(0);
-    ui->sceneWidget->setCameraPitch(0);
-    ui->sceneWidget->setCameraYaw(0);
-    
-    // Reset zoom to default level
-    ui->sceneWidget->resetCameraZoom();
-    
-    // Reset all sliders to 0
+    const int defaultPitch = ui->sceneWidget->isNative3DModel()
+                                 ? NATIVE_3D_DEFAULT_PITCH
+                                 : 0;
+    const int defaultYaw = ui->sceneWidget->isNative3DModel()
+                               ? NATIVE_3D_DEFAULT_YAW
+                               : 0;
+
+    // Block the controls while applying one coherent camera preset.
     QSignalBlocker rollBlocker(ui->rollSlider);
     QSignalBlocker pitchBlocker(ui->pitchSlider);
     QSignalBlocker yawBlocker(ui->yawSlider);
     QSignalBlocker rollSpinBoxBlocker(ui->rollSpinBox);
     QSignalBlocker pitchSpinBoxBlocker(ui->pitchSpinBox);
     QSignalBlocker yawSpinBoxBlocker(ui->yawSpinBox);
-    
+
+    // Azimuth/elevation are not represented by GUI controls, so they must stay
+    // neutral. The native-3D oblique preset uses visible Pitch/Yaw instead.
+    ui->sceneWidget->setCameraAzimuth(0);
+    ui->sceneWidget->setCameraElevation(0);
+    ui->sceneWidget->setCameraRoll(0);
+    ui->sceneWidget->setCameraPitch(defaultPitch);
+    ui->sceneWidget->setCameraYaw(defaultYaw);
+
+    // Reset zoom to default level
+    ui->sceneWidget->resetCameraZoom();
+
     ui->rollSlider->setValue(0);
     ui->rollSpinBox->setValue(0);
-    ui->pitchSlider->setValue(0);
-    ui->pitchSpinBox->setValue(0);
-    ui->yawSlider->setValue(0);
-    ui->yawSpinBox->setValue(0);
+    ui->pitchSlider->setValue(defaultPitch);
+    ui->pitchSpinBox->setValue(defaultPitch);
+    ui->yawSlider->setValue(defaultYaw);
+    ui->yawSpinBox->setValue(defaultYaw);
 }
 
 void MainWindow::onCameraOrientationChanged(double azimuth, double elevation, double roll, double pitch, double yaw)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -203,6 +203,7 @@ void MainWindow::connectMenuActions()
     // View mode actions
     connect(ui->action2DMode, &QAction::triggered, this, &MainWindow::on2DModeRequested);
     connect(ui->action3DMode, &QAction::triggered, this, &MainWindow::on3DModeRequested);
+    connect(ui->actionCrossSectionControls, &QAction::toggled, this, &MainWindow::onCrossSectionControlsToggled);
     connect(ui->actionGridLines, &QAction::triggered, this, &MainWindow::onGridLinesToggled);
     connect(ui->actionFlatSceneBackground, &QAction::triggered, this, &MainWindow::onFlatSceneBackgroundToggled);
 
@@ -316,6 +317,24 @@ void MainWindow::connectSliders()
 
     // Update sliders when camera changes (e.g., via mouse rotation in 3D mode)
     connect(ui->sceneWidget, &SceneWidget::cameraOrientationChanged, this, &MainWindow::onCameraOrientationChanged);
+
+    // Native 3D volume / axis-aligned cross-section controls
+    connect(ui->sliceViewComboBox,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this,
+            &MainWindow::onSliceViewChanged);
+    connect(ui->sliceSlider,
+            &QSlider::valueChanged,
+            this,
+            &MainWindow::onSliceChanged);
+    connect(ui->sliceSpinBox,
+            QOverload<int>::of(&QSpinBox::valueChanged),
+            ui->sliceSlider,
+            &QSlider::setValue);
+    connect(ui->sliceSlider,
+            &QSlider::valueChanged,
+            ui->sliceSpinBox,
+            &QSpinBox::setValue);
 }
 
 void MainWindow::loadStrings()
@@ -1345,7 +1364,15 @@ void MainWindow::on2DModeRequested()
         return;
     }
 
+    if (ui->sceneWidget->isCrossSectionView())
+        ui->sceneWidget->clearCrossSection();
+
     ui->sceneWidget->setViewMode2D();
+    {
+        QSignalBlocker blocker(ui->actionCrossSectionControls);
+        ui->actionCrossSectionControls->setChecked(false);
+    }
+    updateSliceControls(true);
     updateCameraControlsVisibility();
 
     // Synchronize menu checkboxes - ensure only 2D mode is checked
@@ -1362,7 +1389,20 @@ void MainWindow::on2DModeRequested()
 
 void MainWindow::on3DModeRequested()
 {
-    ui->sceneWidget->setViewMode3D();
+    if (ui->sceneWidget->isCrossSectionView())
+    {
+        ui->sceneWidget->clearCrossSection();
+        QSignalBlocker viewBlocker(ui->sliceViewComboBox);
+        ui->sliceViewComboBox->setCurrentIndex(0);
+        ui->sliceAxisLabel->setEnabled(false);
+        ui->sliceSlider->setEnabled(false);
+        ui->sliceSpinBox->setEnabled(false);
+        ui->sliceRangeLabel->setEnabled(false);
+    }
+    else
+    {
+        ui->sceneWidget->setViewMode3D();
+    }
 
     onResetCameraRequested();
 
@@ -1388,6 +1428,11 @@ void MainWindow::synchronizeViewModeWithLoadedModel()
     // A 2D model still keeps 3D available for "substate as altitude".
     ui->action2DMode->setEnabled(!native3D);
     ui->action3DMode->setEnabled(true);
+    {
+        QSignalBlocker blocker(ui->actionCrossSectionControls);
+        ui->actionCrossSectionControls->setChecked(false);
+    }
+    updateSliceControls(true);
 
     if (native3D)
         on3DModeRequested();
@@ -1425,8 +1470,187 @@ void MainWindow::syncFlatSceneBackgroundCheckbox()
 
 void MainWindow::updateCameraControlsVisibility()
 {
-    const bool is3DMode = (ui->sceneWidget->getViewMode() == ViewMode::Mode3D);
+    const bool is3DMode =
+        ui->sceneWidget->getViewMode() == ViewMode::Mode3D &&
+        !ui->sceneWidget->isCrossSectionView();
     ui->camera3DControlsWidget->setVisible(is3DMode);
+}
+
+void MainWindow::updateSliceControls(bool resetSelection)
+{
+    const bool available = ui->sceneWidget->hasSliceable3DView();
+    ui->actionCrossSectionControls->setEnabled(available);
+    ui->sliceControlsWidget->setVisible(
+        available && ui->actionCrossSectionControls->isChecked());
+
+    if (!available)
+    {
+        QSignalBlocker blocker(ui->actionCrossSectionControls);
+        ui->actionCrossSectionControls->setChecked(false);
+        return;
+    }
+
+    if (!resetSelection)
+        return;
+
+    QSignalBlocker viewBlocker(ui->sliceViewComboBox);
+    QSignalBlocker sliderBlocker(ui->sliceSlider);
+    QSignalBlocker spinBlocker(ui->sliceSpinBox);
+    ui->sliceViewComboBox->clear();
+    if (ui->sceneWidget->isNative3DModel())
+    {
+        ui->sliceViewComboBox->addItem(tr("Volume"));
+        ui->sliceViewComboBox->addItem(tr("XY plane (fixed Z)"));
+        ui->sliceViewComboBox->addItem(tr("XZ plane (fixed Y)"));
+        ui->sliceViewComboBox->addItem(tr("YZ plane (fixed X)"));
+    }
+    else
+    {
+        ui->sliceViewComboBox->addItem(tr("3D substate surface"));
+        ui->sliceViewComboBox->addItem(tr("XZ profile (fixed Y)"));
+        ui->sliceViewComboBox->addItem(tr("YZ profile (fixed X)"));
+    }
+    ui->sliceViewComboBox->setCurrentIndex(0);
+    ui->sliceSlider->setRange(0, 0);
+    ui->sliceSpinBox->setRange(0, 0);
+    ui->sliceSlider->setValue(0);
+    ui->sliceSpinBox->setValue(0);
+    ui->sliceAxisLabel->setText("Z:");
+    ui->sliceRangeLabel->setText("/ 0");
+    ui->sliceAxisLabel->setEnabled(false);
+    ui->sliceSlider->setEnabled(false);
+    ui->sliceSpinBox->setEnabled(false);
+    ui->sliceRangeLabel->setEnabled(false);
+}
+
+void MainWindow::onCrossSectionControlsToggled(bool checked)
+{
+    if (!checked)
+    {
+        const bool crossSectionWasActive = ui->sceneWidget->isCrossSectionView();
+        if (crossSectionWasActive)
+            ui->sceneWidget->clearCrossSection();
+        ui->sliceControlsWidget->hide();
+        if (crossSectionWasActive)
+        {
+            QSignalBlocker blocker2D(ui->action2DMode);
+            QSignalBlocker blocker3D(ui->action3DMode);
+            ui->action2DMode->setChecked(false);
+            ui->action3DMode->setChecked(true);
+            onResetCameraRequested();
+        }
+        updateCameraControlsVisibility();
+        syncFlatSceneBackgroundCheckbox();
+        return;
+    }
+
+    if (!ui->sceneWidget->hasSliceable3DView())
+    {
+        QSignalBlocker blocker(ui->actionCrossSectionControls);
+        ui->actionCrossSectionControls->setChecked(false);
+        return;
+    }
+
+    updateSliceControls(true);
+    ui->sliceControlsWidget->show();
+}
+
+void MainWindow::onSliceViewChanged(int viewIndex)
+{
+    if (!ui->sceneWidget->hasSliceable3DView())
+        return;
+
+    if (viewIndex <= 0)
+    {
+        on3DModeRequested();
+        return;
+    }
+
+    const SettingParameter* settings = ui->sceneWidget->getSettingParameter();
+    if (!settings)
+        return;
+
+    GridSliceAxis axis;
+    int axisSize;
+    QString axisName;
+    if (ui->sceneWidget->isNative3DModel())
+    {
+        axis = GridSliceAxis::Z;
+        axisSize = settings->numberOfSlicesZ;
+        axisName = "Z:";
+        if (viewIndex == 2)
+        {
+            axis = GridSliceAxis::Y;
+            axisSize = settings->numberOfRowsY;
+            axisName = "Y:";
+        }
+        else if (viewIndex == 3)
+        {
+            axis = GridSliceAxis::X;
+            axisSize = settings->numberOfColumnX;
+            axisName = "X:";
+        }
+    }
+    else
+    {
+        axis = viewIndex == 1 ? GridSliceAxis::Y : GridSliceAxis::X;
+        axisSize = axis == GridSliceAxis::Y
+            ? settings->numberOfRowsY
+            : settings->numberOfColumnX;
+        axisName = axis == GridSliceAxis::Y ? "Y:" : "X:";
+    }
+
+    const int maximum = std::max(0, axisSize - 1);
+    const int initialIndex = maximum / 2;
+    {
+        QSignalBlocker sliderBlocker(ui->sliceSlider);
+        QSignalBlocker spinBlocker(ui->sliceSpinBox);
+        ui->sliceSlider->setRange(0, maximum);
+        ui->sliceSpinBox->setRange(0, maximum);
+        ui->sliceSlider->setValue(initialIndex);
+        ui->sliceSpinBox->setValue(initialIndex);
+    }
+    ui->sliceAxisLabel->setText(axisName);
+    ui->sliceRangeLabel->setText(QString("/ %1").arg(maximum));
+    ui->sliceAxisLabel->setEnabled(true);
+    ui->sliceSlider->setEnabled(true);
+    ui->sliceSpinBox->setEnabled(true);
+    ui->sliceRangeLabel->setEnabled(true);
+
+    if (ui->sceneWidget->isNative3DModel())
+        ui->sceneWidget->setNative3DSlice(axis, initialIndex);
+    else
+        ui->sceneWidget->setSubstate3DSlice(axis, initialIndex);
+
+    QSignalBlocker blocker2D(ui->action2DMode);
+    QSignalBlocker blocker3D(ui->action3DMode);
+    ui->action2DMode->setChecked(true);
+    ui->action3DMode->setChecked(false);
+    updateCameraControlsVisibility();
+    syncFlatSceneBackgroundCheckbox();
+}
+
+void MainWindow::onSliceChanged(int fixedIndex)
+{
+    const int viewIndex = ui->sliceViewComboBox->currentIndex();
+    if (viewIndex <= 0 || !ui->sceneWidget->hasSliceable3DView())
+        return;
+
+    if (ui->sceneWidget->isNative3DModel())
+    {
+        GridSliceAxis axis = GridSliceAxis::Z;
+        if (viewIndex == 2)
+            axis = GridSliceAxis::Y;
+        else if (viewIndex == 3)
+            axis = GridSliceAxis::X;
+        ui->sceneWidget->setNative3DSlice(axis, fixedIndex);
+    }
+    else
+    {
+        const GridSliceAxis axis =
+            viewIndex == 1 ? GridSliceAxis::Y : GridSliceAxis::X;
+        ui->sceneWidget->setSubstate3DSlice(axis, fixedIndex);
+    }
 }
 
 void MainWindow::syncCameraSliders()
@@ -1803,6 +2027,9 @@ void MainWindow::setWidgetsEnabledState(bool enabled)
     ui->actionShow_config_details->setEnabled(enabled);
     ui->actionExport_Video->setEnabled(enabled);
     ui->actionReloadData->setEnabled(enabled);
+    ui->sliceControlsWidget->setEnabled(enabled);
+    ui->actionCrossSectionControls->setEnabled(
+        enabled && ui->sceneWidget->hasSliceable3DView());
 
     // Native 3D models cannot be flattened; 2D models retain optional 3D substates.
     ui->action2DMode->setEnabled(!ui->sceneWidget->isNative3DModel());
@@ -2285,6 +2512,13 @@ void MainWindow::onUse3dStateChanged(const std::string& fieldName, bool checked)
     {
         // Show wait cursor during view mode change
         WaitCursorGuard waitCursor("Switching to 2D visualization...");
+
+        if (ui->sceneWidget->isCrossSectionView())
+            ui->sceneWidget->clearCrossSection();
+        {
+            QSignalBlocker blocker(ui->actionCrossSectionControls);
+            ui->actionCrossSectionControls->setChecked(false);
+        }
         
         // Disable 3D substate visualization
         ui->sceneWidget->setActiveSubstateFor3D("");
@@ -2297,6 +2531,7 @@ void MainWindow::onUse3dStateChanged(const std::string& fieldName, bool checked)
         
         // Refresh visualization
         ui->sceneWidget->refreshVisualization();
+        updateSliceControls(true);
         return;
     }
     
@@ -2318,6 +2553,14 @@ void MainWindow::onUse3dStateChanged(const std::string& fieldName, bool checked)
 
     // Initialize and draw the 3D substate visualization (this will create the quad mesh)
     ui->sceneWidget->initializeAndDraw3DSubstateVisualization();
+
+    // Cross-section controls are available for the height field, but remain
+    // opt-in through View -> Cross-section controls.
+    {
+        QSignalBlocker blocker(ui->actionCrossSectionControls);
+        ui->actionCrossSectionControls->setChecked(false);
+    }
+    updateSliceControls(true);
     
     // Cursor restored automatically by WaitCursorGuard destructor
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -88,7 +88,7 @@ private slots: // menu actions
     void onPitchChanged(int value);
     void onYawChanged(int value);
     void onResetCameraRequested();
-    void onCameraOrientationChanged(double azimuth, double elevation, double roll, double pitch, double yaw);
+    void onCameraOrientationChanged(double roll, double pitch, double yaw);
     void syncCameraSliders();
 
     void onUse3dStateChanged(const std::string& fieldName, bool checked);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -153,6 +153,7 @@ private:
     void recreateModelMenuActions();
     void createViewModeActionGroup();
     void updateCameraControlsVisibility();
+    void synchronizeViewModeWithLoadedModel();
 
     /// @brief Clear all active substates (2D and 3D)
     void clearActiveSubstates();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -90,6 +90,9 @@ private slots: // menu actions
     void onResetCameraRequested();
     void onCameraOrientationChanged(double roll, double pitch, double yaw);
     void syncCameraSliders();
+    void onCrossSectionControlsToggled(bool checked);
+    void onSliceViewChanged(int viewIndex);
+    void onSliceChanged(int fixedIndex);
 
     void onUse3dStateChanged(const std::string& fieldName, bool checked);
     void onUseSubstatesColorringRequested(const std::vector<std::string>& fieldNames);
@@ -153,6 +156,7 @@ private:
     void recreateModelMenuActions();
     void createViewModeActionGroup();
     void updateCameraControlsVisibility();
+    void updateSliceControls(bool resetSelection = false);
     void synchronizeViewModeWithLoadedModel();
 
     /// @brief Clear all active substates (2D and 3D)

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -40,7 +40,7 @@
     <property name="spacing">
      <number>0</number>
     </property>
-    <item row="16" column="2" colspan="2">
+    <item row="17" column="2" colspan="2">
      <widget class="QWidget" name="camera3DControlsWidget" native="true">
       <property name="visible">
        <bool>false</bool>
@@ -201,6 +201,117 @@
       </layout>
      </widget>
     </item>
+    <item row="15" column="2" colspan="2">
+     <widget class="QWidget" name="sliceControlsWidget" native="true">
+      <property name="visible">
+       <bool>false</bool>
+      </property>
+      <layout class="QHBoxLayout" name="sliceControlsLayout">
+       <property name="leftMargin">
+        <number>5</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>5</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="sliceViewLabel">
+         <property name="text">
+          <string>Cross-section:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="sliceViewComboBox">
+         <property name="toolTip">
+          <string>Show the complete volume or an axis-aligned 2D cross-section</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Volume</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>XY plane (fixed Z)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>XZ plane (fixed Y)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>YZ plane (fixed X)</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="sliceAxisLabel">
+         <property name="text">
+          <string>Z:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSlider" name="sliceSlider">
+         <property name="toolTip">
+          <string>Index of the fixed axis</string>
+         </property>
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>0</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="sliceSpinBox">
+         <property name="toolTip">
+          <string>Index of the fixed axis</string>
+         </property>
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="sliceRangeLabel">
+         <property name="text">
+          <string>/ 0</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="sliceHorizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </item>
     <item row="14" column="2">
      <widget class="QLabel" name="openConfigurationFileLabel">
       <property name="text">
@@ -211,7 +322,7 @@
       </property>
      </widget>
     </item>
-    <item row="15" column="2">
+    <item row="16" column="2">
      <layout class="QVBoxLayout" name="verticalLayout">
       <property name="leftMargin">
        <number>6</number>
@@ -249,7 +360,7 @@
       </item>
      </layout>
     </item>
-    <item row="17" column="2" colspan="2">
+    <item row="18" column="2" colspan="2">
      <layout class="QHBoxLayout" name="buttonBoxLayout">
       <property name="spacing">
        <number>8</number>
@@ -470,7 +581,7 @@
       </property>
      </widget>
     </item>
-    <item row="18" column="1" colspan="2">
+    <item row="19" column="1" colspan="2">
      <widget class="QFrame" name="frame">
       <property name="frameShape">
        <enum>QFrame::Shape::StyledPanel</enum>
@@ -693,6 +804,8 @@
     <addaction name="action2DMode"/>
     <addaction name="action3DMode"/>
     <addaction name="separator"/>
+    <addaction name="actionCrossSectionControls"/>
+    <addaction name="separator"/>
     <addaction name="actionGridLines"/>
     <addaction name="actionFlatSceneBackground"/>
    </widget>
@@ -872,6 +985,17 @@
    </property>
    <property name="toolTip">
     <string>Switch to 3D perspective view with rotation controls</string>
+   </property>
+  </action>
+  <action name="actionCrossSectionControls">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Cross-section controls</string>
+   </property>
+   <property name="toolTip">
+    <string>Show controls for axis-aligned cross-sections</string>
    </property>
   </action>
   <action name="actionShow_reduction">

--- a/plugins/ModelLoader.cpp
+++ b/plugins/ModelLoader.cpp
@@ -6,7 +6,9 @@
 #include <iostream>
 #include <memory>
 #include <format>
+#include <ranges>
 #include <string>
+#include <vector>
 #include <QString>
 #include <QLibrary>
 
@@ -38,6 +40,26 @@ bool isFileNewer(const std::filesystem::path& a, const std::filesystem::path& b)
 
     // Compare modification times
     return fs::last_write_time(a) > fs::last_write_time(b);
+}
+
+/** Plugins instantiate the reader/visualizer templates from Viewer headers.
+ * Rebuild them when one of those headers changes, even if the model header did not. */
+bool isGeneratedModuleStale(const std::filesystem::path& moduleFile,
+                            const std::filesystem::path& viewerRoot)
+{
+    if (!fs::exists(moduleFile))
+        return true;
+
+    const std::vector<fs::path> templateDependencies = {
+        viewerRoot / "visualiserProxy/SceneWidgetVisualizerProxy.h",
+        viewerRoot / "data/ModelReader.hpp",
+        viewerRoot / "visualiser/Visualizer.hpp"
+    };
+
+    return std::ranges::any_of(templateDependencies, [&](const fs::path& dependency)
+    {
+        return fs::exists(dependency) && fs::last_write_time(dependency) > fs::last_write_time(moduleFile);
+    });
 }
 
 std::string generateClassNameFromCppHeaderFileName(const std::string& cppHeaderFile)
@@ -101,7 +123,11 @@ ModelLoader::LoadResult ModelLoader::loadModelFromDirectory(const std::string& m
         const std::string moduleFileName = generateModuleNameForSourceFile(sourceFile);
 
         // Check if compilation is needed
-        const bool compilationNecessarily = ! moduleExists(moduleFileName) || forceCompilation;
+        const bool compilationNecessarily =
+            !moduleExists(moduleFileName) ||
+            forceCompilation ||
+            isFileNewer(sourceFile, moduleFileName) ||
+            isGeneratedModuleStale(moduleFileName, builder->getProjectRootPath());
         if (compilationNecessarily)
         {
             const std::string wrapperSource = modelDirectory + "/" + result.outputFileName + std::string(DirectoryConstants::WRAPPER_FILE_SUFFIX);

--- a/tests/ModelReaderTests.cpp
+++ b/tests/ModelReaderTests.cpp
@@ -48,6 +48,36 @@ TEST(ParseGridDimensions, Supports2DAnd3DHeaders)
     EXPECT_EQ(dimensions3D.slice, 99);
 }
 
+TEST(ContiguousGridSliceView, MapsAllOrthogonalPlanesWithoutCopying)
+{
+    ContiguousGrid<int> grid(2, 3, 4);
+    for (std::size_t row = 0; row < grid.rowCount(); ++row)
+    {
+        for (std::size_t column = 0; column < grid.columnCount(); ++column)
+        {
+            for (std::size_t layer = 0; layer < grid.layerCount(); ++layer)
+                grid[row, column, layer] = static_cast<int>(100 * row + 10 * column + layer);
+        }
+    }
+
+    const ContiguousGridSliceView<int> xy(grid, GridSliceAxis::Z, 2);
+    EXPECT_EQ(xy.rowCount(), 2);
+    EXPECT_EQ(xy.columnCount(), 3);
+    EXPECT_EQ(xy[1][2], 122);
+
+    const ContiguousGridSliceView<int> xz(grid, GridSliceAxis::Y, 1);
+    EXPECT_EQ(xz.rowCount(), 4);
+    EXPECT_EQ(xz.columnCount(), 3);
+    EXPECT_EQ(xz[0][2], 123); // top row is the highest Z
+    EXPECT_EQ(xz[3][2], 120); // bottom row is Z=0
+
+    const ContiguousGridSliceView<int> yz(grid, GridSliceAxis::X, 2);
+    EXPECT_EQ(yz.rowCount(), 4);
+    EXPECT_EQ(yz.columnCount(), 2);
+    EXPECT_EQ(yz[0][1], 123);
+    EXPECT_EQ(yz[3][0], 20);
+}
+
 TEST(CalculateXYZOffsetForNode, TwoByOneByTwo)
 {
     const std::vector<ColumnRowSlice> dimensions = {

--- a/tests/ModelReaderTests.cpp
+++ b/tests/ModelReaderTests.cpp
@@ -1,7 +1,135 @@
 #include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+#include <string>
 #include <vector>
 #include "core/types.h"
 #include "data/ModelReader.hpp"
+#include "visualiserProxy/ContiguousGrid.h"
+
+namespace
+{
+class TestCell
+{
+public:
+    void composeElement(char* text)
+    {
+        value = std::stoi(text);
+    }
+
+    std::string stringEncoding(const char* = nullptr) const
+    {
+        return std::to_string(value);
+    }
+
+    Color outputValue(const char*, GlobalValueManager*) const
+    {
+        return Color(static_cast<std::uint8_t>(value), 0, 0);
+    }
+
+    void startStep(int)
+    {
+    }
+
+    int value = 0;
+};
+}
+
+TEST(ParseGridDimensions, Supports2DAnd3DHeaders)
+{
+    const auto dimensions2D = ReaderHelpers::getDimensionsFromLine("250-500");
+    EXPECT_EQ(dimensions2D.column, 250);
+    EXPECT_EQ(dimensions2D.row, 500);
+    EXPECT_EQ(dimensions2D.slice, 1);
+
+    const auto dimensions3D = ReaderHelpers::getDimensionsFromLine("50-99-99 ");
+    EXPECT_EQ(dimensions3D.column, 50);
+    EXPECT_EQ(dimensions3D.row, 99);
+    EXPECT_EQ(dimensions3D.slice, 99);
+}
+
+TEST(CalculateXYZOffsetForNode, TwoByOneByTwo)
+{
+    const std::vector<ColumnRowSlice> dimensions = {
+        ColumnRowSlice::xyz(50, 99, 40),
+        ColumnRowSlice::xyz(49, 99, 40),
+        ColumnRowSlice::xyz(50, 99, 59),
+        ColumnRowSlice::xyz(49, 99, 59)
+    };
+
+    const auto node0 = ReaderHelpers::calculateXYZOffsetForNode(0, 2, 1, 2, dimensions);
+    const auto node1 = ReaderHelpers::calculateXYZOffsetForNode(1, 2, 1, 2, dimensions);
+    const auto node2 = ReaderHelpers::calculateXYZOffsetForNode(2, 2, 1, 2, dimensions);
+    const auto node3 = ReaderHelpers::calculateXYZOffsetForNode(3, 2, 1, 2, dimensions);
+
+    EXPECT_EQ(node0.x(), 0);
+    EXPECT_EQ(node0.z(), 0);
+    EXPECT_EQ(node1.x(), 50);
+    EXPECT_EQ(node1.z(), 0);
+    EXPECT_EQ(node2.x(), 0);
+    EXPECT_EQ(node2.z(), 40);
+    EXPECT_EQ(node3.x(), 50);
+    EXPECT_EQ(node3.z(), 40);
+}
+
+TEST(ReadStageState, StitchesAllSlicesFromMultipleTextNodes)
+{
+    namespace fs = std::filesystem;
+    const fs::path directory = fs::temp_directory_path() / "oopencal-viewer-reader-3d-test";
+    fs::remove_all(directory);
+    fs::create_directories(directory);
+    const std::string baseName = (directory / "volume").string();
+
+    {
+        std::ofstream index(baseName + "0_index.txt");
+        index << "0 0\n";
+        std::ofstream data(baseName + "0.txt");
+        data << "1-2-2\n"
+             << "1 \n"
+             << "2 \n"
+             << "3 \n"
+             << "4 \n";
+    }
+    {
+        std::ofstream index(baseName + "1_index.txt");
+        index << "0 0\n";
+        std::ofstream data(baseName + "1.txt");
+        data << "1-2-2\n"
+             << "5 \n"
+             << "6 \n"
+             << "7 \n"
+             << "8 \n";
+    }
+
+    ModelReader<TestCell> reader;
+    reader.readStepsOffsetsForAllNodesFromFiles(2, 1, 1, baseName);
+
+    SettingParameter settings{};
+    settings.step = 0;
+    settings.numberOfColumnX = 2;
+    settings.numberOfRowsY = 2;
+    settings.numberOfSlicesZ = 2;
+    settings.nNodeX = 2;
+    settings.nNodeY = 1;
+    settings.nNodeZ = 1;
+    settings.outputFileName = baseName;
+    settings.readMode = "text";
+
+    ContiguousGrid<TestCell> volume(2, 2, 2);
+    std::vector<Line> lines(7);
+    reader.readStageStateFromFilesForStep(volume, &settings, lines.data());
+
+    EXPECT_EQ((volume[0, 0, 0].value), 1);
+    EXPECT_EQ((volume[1, 0, 0].value), 2);
+    EXPECT_EQ((volume[0, 0, 1].value), 3);
+    EXPECT_EQ((volume[1, 0, 1].value), 4);
+    EXPECT_EQ((volume[0, 1, 0].value), 5);
+    EXPECT_EQ((volume[1, 1, 0].value), 6);
+    EXPECT_EQ((volume[0, 1, 1].value), 7);
+    EXPECT_EQ((volume[1, 1, 1].value), 8);
+
+    fs::remove_all(directory);
+}
 
 /**
  * Test Suite: calculateXYOffsetForNode

--- a/visualiser/Visualiser.cpp
+++ b/visualiser/Visualiser.cpp
@@ -172,6 +172,15 @@ vtkNew<vtkActor2D> Visualizer::buildStepText(StepIndex step,
 
 void Visualizer::drawFlatSceneBackground(int nRows, int nCols, vtkSmartPointer<vtkRenderer> renderer, vtkSmartPointer<vtkActor> backgroundActor)
 {
+    drawFlatSceneBackground(nRows, nCols, renderer, backgroundActor, 0.0);
+}
+
+void Visualizer::drawFlatSceneBackground(int nRows,
+                                         int nCols,
+                                         vtkSmartPointer<vtkRenderer> renderer,
+                                         vtkSmartPointer<vtkActor> backgroundActor,
+                                         double zPosition)
+{
     // Validate inputs
     if (!backgroundActor || !renderer)
     {
@@ -199,14 +208,13 @@ void Visualizer::drawFlatSceneBackground(int nRows, int nCols, vtkSmartPointer<v
     const QColor sceneColor = ColorSettings::instance().flatSceneBackgroundColor();
     lut->SetTableValue(0, sceneColor.redF(), sceneColor.greenF(), sceneColor.blueF(), 1.0);
 
-    // Create flat plane at Z=0
+    // Create the plane at the requested elevation.
     vtkNew<vtkPoints> points;
     for (int row = 0; row < nRows; row++)
     {
         for (int col = 0; col < nCols; col++)
         {
-            // Z=0 for flat background plane
-            points->InsertNextPoint(/*x=*/col, /*y=*/nRows - 1 - row, /*z=*/0);
+            points->InsertNextPoint(/*x=*/col, /*y=*/nRows - 1 - row, /*z=*/zPosition);
         }
     }
 
@@ -223,6 +231,104 @@ void Visualizer::drawFlatSceneBackground(int nRows, int nCols, vtkSmartPointer<v
 
     backgroundActor->SetMapper(backgroundMapper);
     renderer->AddActor(backgroundActor);
+}
+
+vtkSmartPointer<vtkPolyData> Visualizer::create3DVolumeGridLinePolyData(
+    int nRows,
+    int nCols,
+    int nSlices,
+    int nNodeZ,
+    const std::vector<Line>& lines)
+{
+    vtkNew<vtkPoints> points;
+    vtkNew<vtkCellArray> cellLines;
+
+    auto addSegment = [&](double x1, double y1, double z1,
+                          double x2, double y2, double z2)
+    {
+        const vtkIdType first = points->InsertNextPoint(x1, y1, z1);
+        const vtkIdType second = points->InsertNextPoint(x2, y2, z2);
+        cellLines->InsertNextCell(2);
+        cellLines->InsertCellPoint(first);
+        cellLines->InsertCellPoint(second);
+    };
+
+    const double maxX = std::max(0, nCols - 1);
+    const double maxY = std::max(0, nRows - 1);
+    const double maxZ = std::max(0, nSlices - 1);
+
+    for (const auto& line : lines)
+    {
+        const double x1 = std::clamp(static_cast<double>(line.x1), 0.0, maxX);
+        const double x2 = std::clamp(static_cast<double>(line.x2), 0.0, maxX);
+        const double y1 = std::clamp(maxY - line.y1, 0.0, maxY);
+        const double y2 = std::clamp(maxY - line.y2, 0.0, maxY);
+
+        // Extruding every XY node edge through Z produces a wireframe for each
+        // distributed node partition without covering the volume with a solid plane.
+        addSegment(x1, y1, 0.0, x2, y2, 0.0);
+        addSegment(x1, y1, maxZ, x2, y2, maxZ);
+        addSegment(x1, y1, 0.0, x1, y1, maxZ);
+        addSegment(x2, y2, 0.0, x2, y2, maxZ);
+    }
+
+    // XY lines carry exact X/Y partition offsets. Z partition offsets are not
+    // represented by Line, so derive their regular slice boundaries here.
+    for (int nodeZ = 1; nodeZ < nNodeZ; ++nodeZ)
+    {
+        const double z = std::clamp(
+            static_cast<double>(nodeZ * nSlices) / nNodeZ,
+            0.0,
+            maxZ);
+        addSegment(0.0, 0.0, z, maxX, 0.0, z);
+        addSegment(maxX, 0.0, z, maxX, maxY, z);
+        addSegment(maxX, maxY, z, 0.0, maxY, z);
+        addSegment(0.0, maxY, z, 0.0, 0.0, z);
+    }
+
+    vtkNew<vtkPolyData> polyData;
+    polyData->SetPoints(points);
+    polyData->SetLines(cellLines);
+    return polyData;
+}
+
+void Visualizer::drawGridLinesFor3DVolume(int nRows,
+                                          int nCols,
+                                          int nSlices,
+                                          int nNodeZ,
+                                          const std::vector<Line>& lines,
+                                          vtkSmartPointer<vtkRenderer> renderer,
+                                          vtkSmartPointer<vtkActor> gridLinesActor)
+{
+    if (!renderer || !gridLinesActor)
+        return;
+
+    vtkNew<vtkPolyDataMapper> mapper;
+    mapper->SetInputData(create3DVolumeGridLinePolyData(nRows, nCols, nSlices, nNodeZ, lines));
+    gridLinesActor->SetMapper(mapper);
+    gridLinesActor->GetProperty()->SetLineWidth(1.25);
+    gridLinesActor->GetProperty()->SetOpacity(0.8);
+    applyGridColorTo3DGridLinesActor(gridLinesActor);
+    renderer->AddActor(gridLinesActor);
+}
+
+void Visualizer::refreshGridLinesFor3DVolume(int nRows,
+                                             int nCols,
+                                             int nSlices,
+                                             int nNodeZ,
+                                             const std::vector<Line>& lines,
+                                             vtkSmartPointer<vtkActor> gridLinesActor)
+{
+    if (!gridLinesActor)
+        return;
+
+    auto* mapper = vtkPolyDataMapper::SafeDownCast(gridLinesActor->GetMapper());
+    if (!mapper)
+        return;
+
+    mapper->SetInputData(create3DVolumeGridLinePolyData(nRows, nCols, nSlices, nNodeZ, lines));
+    mapper->Update();
+    applyGridColorTo3DGridLinesActor(gridLinesActor);
 }
 
 void Visualizer::refreshFlatSceneBackground(int nRows, int nCols, vtkSmartPointer<vtkActor> backgroundActor)

--- a/visualiser/Visualizer.hpp
+++ b/visualiser/Visualizer.hpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <vector>
 #include <vtkActor2D.h>
@@ -13,9 +14,13 @@
 #include <vtkCoordinate.h>
 #include <vtkDataSetMapper.h>
 #include <vtkDoubleArray.h>
+#include <vtkFloatArray.h>
 #include <vtkLookupTable.h>
 #include <vtkNamedColors.h>
+#include <vtkImageData.h>
 #include <vtkNew.h>
+#include <vtkColorTransferFunction.h>
+#include <vtkPiecewiseFunction.h>
 #include <vtkPointData.h>
 #include <vtkPoints.h>
 #include <vtkPolyData.h>
@@ -30,6 +35,9 @@
 #include <vtkPolyDataNormals.h>
 #include <vtkCellData.h>
 #include <vtkProperty.h>
+#include <vtkSmartVolumeMapper.h>
+#include <vtkVolume.h>
+#include <vtkVolumeProperty.h>
 
 #include "core/types.h"    // StepIndex
 #include "OOpenCAL/base/Cell.h" // Color
@@ -73,6 +81,18 @@ public:
     void drawWithVTK(const Matrix& p, int nRows, int nCols, vtkSmartPointer<vtkRenderer> renderer, vtkSmartPointer<vtkActor> gridActor, const std::vector<const SubstateInfo*>& colorSubstateInfos={}, bool useCellRendering=false);
     template<class Matrix>
     void refreshWindowsVTK(const Matrix& p, int nRows, int nCols, vtkSmartPointer<vtkActor> gridActor, const std::vector<const SubstateInfo*>& colorSubstateInfos);
+
+    /** @brief Render a native 3D cellular grid as a volume.
+     *
+     * This path is separate from the 2D "substate as altitude" surface. */
+    template<class Volume>
+    void drawWithVTK3DVolume(const Volume& p,
+                             int nRows,
+                             int nCols,
+                             int nSlices,
+                             vtkSmartPointer<vtkRenderer> renderer,
+                             vtkSmartPointer<vtkVolume> volumeActor,
+                             const std::vector<const SubstateInfo*>& colorSubstateInfos);
 
     /// @brief Draw 3D substate visualization as a quad mesh surface (new healed quad approach).
     template<class Matrix>
@@ -170,7 +190,7 @@ private:
 
     /// @brief This function is to decrease dependencies with Qt (Visualiser.hpp is used in module compilation, so we don't want Qt)
     Color flatSceneBackgroundColor() const;
-    GlobalValueManager* gvm;
+    GlobalValueManager* gvm = nullptr;
 };
 
 ////////////////////////////////////////////////////////////////////
@@ -293,6 +313,125 @@ void Visualizer::refreshWindowsVTK(const Matrix &p, int nRows, int nCols, vtkSma
     }
     else
         throw std::runtime_error("Invalid dynamic cast!");
+}
+
+template<class Volume>
+void Visualizer::drawWithVTK3DVolume(const Volume& p,
+                                     int nRows,
+                                     int nCols,
+                                     int nSlices,
+                                     vtkSmartPointer<vtkRenderer> renderer,
+                                     vtkSmartPointer<vtkVolume> volumeActor,
+                                     const std::vector<const SubstateInfo*>& colorSubstateInfos)
+{
+    if (!renderer || !volumeActor || nRows <= 0 || nCols <= 0 || nSlices <= 1)
+        return;
+
+    const char* fieldName = nullptr;
+    if (!colorSubstateInfos.empty() && colorSubstateInfos.front() &&
+        !colorSubstateInfos.front()->name.empty())
+    {
+        fieldName = colorSubstateInfos.front()->name.c_str();
+    }
+
+    const vtkIdType valueCount =
+        static_cast<vtkIdType>(nRows) * nCols * nSlices;
+    vtkNew<vtkFloatArray> scalars;
+    scalars->SetName("cell-value");
+    scalars->SetNumberOfValues(valueCount);
+
+    double minValue = std::numeric_limits<double>::infinity();
+    double maxValue = -std::numeric_limits<double>::infinity();
+    Color minColor(255, 255, 255);
+    Color maxColor(255, 255, 255);
+
+    for (int slice = 0; slice < nSlices; ++slice)
+    {
+        for (int row = 0; row < nRows; ++row)
+        {
+            for (int col = 0; col < nCols; ++col)
+            {
+                double value = 0.0;
+                try
+                {
+                    value = std::stod(p[row, col, slice].stringEncoding(fieldName));
+                }
+                catch (...)
+                {
+                    value = 0.0;
+                }
+
+                const Color color = p[row, col, slice].outputValue(fieldName, gvm);
+                if (value < minValue)
+                {
+                    minValue = value;
+                    minColor = color;
+                }
+                if (value > maxValue)
+                {
+                    maxValue = value;
+                    maxColor = color;
+                }
+
+                // VTK expects X to vary fastest. Invert Y just like the existing 2D renderer.
+                const vtkIdType index =
+                    (static_cast<vtkIdType>(slice) * nRows + (nRows - 1 - row)) *
+                    nCols +
+                    col;
+                scalars->SetValue(index, static_cast<float>(value));
+            }
+        }
+    }
+
+    if (!std::isfinite(minValue) || !std::isfinite(maxValue))
+        return;
+
+    vtkNew<vtkImageData> image;
+    image->SetDimensions(nCols, nRows, nSlices);
+    image->SetOrigin(0.0, 0.0, 0.0);
+    image->SetSpacing(1.0, 1.0, 1.0);
+    image->GetPointData()->SetScalars(scalars);
+
+    vtkNew<vtkColorTransferFunction> colors;
+    vtkNew<vtkPiecewiseFunction> opacity;
+
+    auto addColor = [&](double value, const Color& color)
+    {
+        colors->AddRGBPoint(value,
+                            toUnitColor(color.getRed()),
+                            toUnitColor(color.getGreen()),
+                            toUnitColor(color.getBlue()));
+    };
+
+    if (minValue < maxValue)
+    {
+        addColor(minValue, minColor);
+        addColor(maxValue, maxColor);
+        opacity->AddPoint(minValue, 0.0);
+        opacity->AddPoint(maxValue, 0.9);
+    }
+    else
+    {
+        addColor(minValue - 1.0, minColor);
+        addColor(minValue, minColor);
+        opacity->AddPoint(minValue - 1.0, 0.0);
+        opacity->AddPoint(minValue, minValue == 0.0 ? 0.0 : 0.9);
+    }
+
+    vtkNew<vtkVolumeProperty> property;
+    property->SetColor(colors);
+    property->SetScalarOpacity(opacity);
+    property->SetInterpolationTypeToNearest();
+    property->ShadeOff();
+
+    vtkNew<vtkSmartVolumeMapper> mapper;
+    mapper->SetInputData(image);
+    mapper->SetBlendModeToComposite();
+    mapper->SetAutoAdjustSampleDistances(true);
+
+    volumeActor->SetMapper(mapper);
+    volumeActor->SetProperty(property);
+    renderer->AddVolume(volumeActor);
 }
 
 template<class Matrix>

--- a/visualiser/Visualizer.hpp
+++ b/visualiser/Visualizer.hpp
@@ -126,8 +126,31 @@ public:
 
     /// @brief Draw flat background plane at Z=0 for 3D visualization.
     void drawFlatSceneBackground(int nRows, int nCols, vtkSmartPointer<vtkRenderer> renderer, vtkSmartPointer<vtkActor> backgroundActor);
+    /// @brief Draw a flat background plane at a selected Z coordinate.
+    void drawFlatSceneBackground(int nRows,
+                                 int nCols,
+                                 vtkSmartPointer<vtkRenderer> renderer,
+                                 vtkSmartPointer<vtkActor> backgroundActor,
+                                 double zPosition);
     /// @brief Refresh flat background plane colors.
     void refreshFlatSceneBackground(int nRows, int nCols, vtkSmartPointer<vtkActor> backgroundActor);
+
+    /// @brief Draw node-boundary wireframes around a native 3D volume.
+    void drawGridLinesFor3DVolume(int nRows,
+                                  int nCols,
+                                  int nSlices,
+                                  int nNodeZ,
+                                  const std::vector<Line>& lines,
+                                  vtkSmartPointer<vtkRenderer> renderer,
+                                  vtkSmartPointer<vtkActor> gridLinesActor);
+
+    /// @brief Refresh node-boundary wireframes around a native 3D volume.
+    void refreshGridLinesFor3DVolume(int nRows,
+                                     int nCols,
+                                     int nSlices,
+                                     int nNodeZ,
+                                     const std::vector<Line>& lines,
+                                     vtkSmartPointer<vtkActor> gridLinesActor);
 
     void buildLoadBalanceLine(const std::vector<Line>& lines, int nRows, vtkSmartPointer<vtkRenderer> renderer, vtkSmartPointer<vtkActor2D> actorBuildLine);
     void refreshBuildLoadBalanceLine(const std::vector<Line> &lines, int nRows, vtkActor2D* lineActor);
@@ -187,6 +210,12 @@ private:
       * @param nRows Number of grid rows (used to invert Y coordinates)
       * @return vtkSmartPointer<vtkPolyData> with points and lines set */
     vtkSmartPointer<vtkPolyData> createLinePolyData(const std::vector<Line>& lines, int nRows);
+
+    vtkSmartPointer<vtkPolyData> create3DVolumeGridLinePolyData(int nRows,
+                                                                int nCols,
+                                                                int nSlices,
+                                                                int nNodeZ,
+                                                                const std::vector<Line>& lines);
 
     /// @brief This function is to decrease dependencies with Qt (Visualiser.hpp is used in module compilation, so we don't want Qt)
     Color flatSceneBackgroundColor() const;
@@ -386,6 +415,19 @@ void Visualizer::drawWithVTK3DVolume(const Volume& p,
     if (!std::isfinite(minValue) || !std::isfinite(maxValue))
         return;
 
+    // A model may intentionally use pure black for occupied cells (Ball3D does).
+    // Pure black has no diffuse lighting response and therefore looks like a flat
+    // disk from every angle. Lift only near-black foreground colors to charcoal
+    // so the original hue remains intact while surface shading becomes visible.
+    auto makeShadeable = [](const Color& color)
+    {
+        const int brightness = color.getRed() + color.getGreen() + color.getBlue();
+        if (brightness < 48)
+            return Color(70, 82, 100);
+        return color;
+    };
+    maxColor = makeShadeable(maxColor);
+
     vtkNew<vtkImageData> image;
     image->SetDimensions(nCols, nRows, nSlices);
     image->SetOrigin(0.0, 0.0, 0.0);
@@ -422,7 +464,12 @@ void Visualizer::drawWithVTK3DVolume(const Volume& p,
     property->SetColor(colors);
     property->SetScalarOpacity(opacity);
     property->SetInterpolationTypeToNearest();
-    property->ShadeOff();
+    property->ShadeOn();
+    property->SetAmbient(0.22);
+    property->SetDiffuse(0.78);
+    property->SetSpecular(0.35);
+    property->SetSpecularPower(18.0);
+    property->SetScalarOpacityUnitDistance(0.8);
 
     vtkNew<vtkSmartVolumeMapper> mapper;
     mapper->SetInputData(image);

--- a/visualiser/Visualizer.hpp
+++ b/visualiser/Visualizer.hpp
@@ -101,6 +101,20 @@ public:
     template<class Matrix>
     void refreshWindowsVTK3DSubstate(const Matrix& p, int nRows, int nCols, vtkSmartPointer<vtkActor> gridActor, const std::string& substateFieldName, double minValue, double maxValue, const std::vector<const SubstateInfo*>& colorSubstateInfos);
 
+    /// @brief Draw a vertical XZ or YZ profile through a 2D height-field substate.
+    template<class Matrix>
+    void drawWithVTK3DSubstateSlice(const Matrix& p,
+                                    int nRows,
+                                    int nCols,
+                                    vtkSmartPointer<vtkRenderer> renderer,
+                                    vtkSmartPointer<vtkActor> gridActor,
+                                    const std::string& substateFieldName,
+                                    double minValue,
+                                    double maxValue,
+                                    const std::vector<const SubstateInfo*>& colorSubstateInfos,
+                                    GridSliceAxis fixedAxis,
+                                    int fixedIndex);
+
     /// @brief Draw node grid lines projected onto the 3D substate surface.
     template<class Matrix>
     void drawGridLinesOn3DSurface(const Matrix& p,
@@ -1036,4 +1050,91 @@ void Visualizer::refreshWindowsVTK3DSubstate(const Matrix& p, int nRows, int nCo
 
     mapper->SetInputData(surfacePolyData);
     mapper->Update();
+}
+
+template<class Matrix>
+void Visualizer::drawWithVTK3DSubstateSlice(
+    const Matrix& p,
+    int nRows,
+    int nCols,
+    vtkSmartPointer<vtkRenderer> renderer,
+    vtkSmartPointer<vtkActor> gridActor,
+    const std::string& substateFieldName,
+    double minValue,
+    double maxValue,
+    const std::vector<const SubstateInfo*>& colorSubstateInfos,
+    GridSliceAxis fixedAxis,
+    int fixedIndex)
+{
+    if (!renderer || !gridActor ||
+        (fixedAxis != GridSliceAxis::X && fixedAxis != GridSliceAxis::Y) ||
+        std::isnan(minValue) || std::isnan(maxValue) || minValue >= maxValue)
+    {
+        return;
+    }
+
+    const int sampleCount = fixedAxis == GridSliceAxis::Y ? nCols : nRows;
+    const int clampedFixedIndex = fixedAxis == GridSliceAxis::Y
+        ? std::clamp(fixedIndex, 0, nRows - 1)
+        : std::clamp(fixedIndex, 0, nCols - 1);
+
+    vtkNew<vtkPoints> points;
+    vtkNew<vtkCellArray> cells;
+    vtkNew<vtkUnsignedCharArray> cellColors;
+    cellColors->SetNumberOfComponents(3);
+
+    for (int sample = 0; sample < sampleCount; ++sample)
+    {
+        const int row = fixedAxis == GridSliceAxis::Y ? clampedFixedIndex : sample;
+        const int col = fixedAxis == GridSliceAxis::Y ? sample : clampedFixedIndex;
+
+        double value = minValue;
+        try
+        {
+            value = std::stod(p[row][col].stringEncoding(substateFieldName.c_str()));
+        }
+        catch (...)
+        {
+            continue;
+        }
+
+        if (!std::isfinite(value) || value <= minValue)
+            continue;
+
+        value = std::clamp(value, minValue, maxValue);
+        const double x0 = static_cast<double>(sample);
+        const double x1 = static_cast<double>(sample + 1);
+        const vtkIdType ids[4] = {
+            points->InsertNextPoint(x0, minValue, 1.0),
+            points->InsertNextPoint(x1, minValue, 1.0),
+            points->InsertNextPoint(x1, value, 1.0),
+            points->InsertNextPoint(x0, value, 1.0)
+        };
+
+        cells->InsertNextCell(4);
+        for (const vtkIdType id : ids)
+            cells->InsertCellPoint(id);
+
+        const Color color = calculateCellColor(row, col, p, colorSubstateInfos);
+        cellColors->InsertNextTuple3(color.getRed(), color.getGreen(), color.getBlue());
+    }
+
+    vtkNew<vtkPolyData> profile;
+    profile->SetPoints(points);
+    profile->SetPolys(cells);
+    profile->GetCellData()->SetScalars(cellColors);
+
+    vtkNew<vtkPolyDataMapper> mapper;
+    mapper->SetInputData(profile);
+    mapper->SetScalarModeToUseCellData();
+    mapper->ScalarVisibilityOn();
+
+    renderer->RemoveActor(gridActor);
+    gridActor->SetMapper(mapper);
+    gridActor->GetProperty()->SetInterpolationToFlat();
+    gridActor->GetProperty()->SetAmbient(1.0);
+    gridActor->GetProperty()->SetDiffuse(0.0);
+    gridActor->GetProperty()->SetSpecular(0.0);
+    gridActor->GetProperty()->EdgeVisibilityOff();
+    renderer->AddActor(gridActor);
 }

--- a/visualiserProxy/ContiguousGrid.h
+++ b/visualiserProxy/ContiguousGrid.h
@@ -10,6 +10,8 @@
 #include <cstddef>
 #include <vector>
 
+#include "core/types.h"
+
 /** @class ContiguousGrid
  * @brief Stores grid data in a single contiguous std::vector.
  *
@@ -178,4 +180,102 @@ private:
     size_type rowCount_ = 0;
     size_type columnCount_ = 0;
     size_type layerCount_ = 1;
+};
+
+/** @class ContiguousGridSliceView
+ * @brief Non-owning 2D view of one axis-aligned plane in a 3D grid.
+ *
+ * The view presents the selected plane through the familiar `view[row][column]`
+ * interface used by the existing 2D renderer. XZ and YZ planes reverse their
+ * Z-backed row so Z=0 is displayed at the bottom of the 2D view. */
+template<typename T>
+class ContiguousGridSliceView
+{
+public:
+    using size_type = typename ContiguousGrid<T>::size_type;
+
+    class RowProxy
+    {
+    public:
+        [[nodiscard]] const T& operator[](size_type column) const noexcept
+        {
+            return view_->at(row_, column);
+        }
+
+    private:
+        friend class ContiguousGridSliceView;
+
+        RowProxy(const ContiguousGridSliceView* view, size_type row) noexcept
+            : view_(view)
+            , row_(row)
+        {
+        }
+
+        const ContiguousGridSliceView* view_;
+        size_type row_;
+    };
+
+    ContiguousGridSliceView(const ContiguousGrid<T>& grid,
+                            GridSliceAxis axis,
+                            size_type fixedIndex) noexcept
+        : grid_(grid)
+        , axis_(axis)
+        , fixedIndex_(fixedIndex)
+    {
+        assert(fixedIndex_ < fixedAxisSize());
+    }
+
+    [[nodiscard]] size_type rowCount() const noexcept
+    {
+        return axis_ == GridSliceAxis::Z ? grid_.rowCount() : grid_.layerCount();
+    }
+
+    [[nodiscard]] size_type columnCount() const noexcept
+    {
+        return axis_ == GridSliceAxis::X ? grid_.rowCount() : grid_.columnCount();
+    }
+
+    [[nodiscard]] RowProxy operator[](size_type row) const noexcept
+    {
+        assert(row < rowCount());
+        return RowProxy(this, row);
+    }
+
+private:
+    [[nodiscard]] size_type fixedAxisSize() const noexcept
+    {
+        switch (axis_)
+        {
+            case GridSliceAxis::X:
+                return grid_.columnCount();
+            case GridSliceAxis::Y:
+                return grid_.rowCount();
+            case GridSliceAxis::Z:
+                return grid_.layerCount();
+        }
+        return 0;
+    }
+
+    [[nodiscard]] const T& at(size_type row, size_type column) const noexcept
+    {
+        assert(row < rowCount());
+        assert(column < columnCount());
+
+        switch (axis_)
+        {
+            case GridSliceAxis::X:
+                return grid_[column, fixedIndex_, grid_.layerCount() - 1 - row];
+            case GridSliceAxis::Y:
+                return grid_[fixedIndex_, column, grid_.layerCount() - 1 - row];
+            case GridSliceAxis::Z:
+                return grid_[row, column, fixedIndex_];
+        }
+
+        assert(false);
+        return grid_[0, 0, 0];
+    }
+
+    const ContiguousGrid<T>& grid_;
+    GridSliceAxis axis_;
+    size_type fixedIndex_;
 };

--- a/visualiserProxy/ISceneWidgetVisualizer.h
+++ b/visualiserProxy/ISceneWidgetVisualizer.h
@@ -21,6 +21,7 @@
 #include <vtkRenderer.h>
 
 #include "core/types.h"
+#include "visualiserProxy/ContiguousGrid.h"
 
 // Forward declarations
 struct SettingParameter;
@@ -68,11 +69,38 @@ public:
     /// @brief Refresh the VTK windows.
     virtual void refreshWindowsVTK(int nRows, int nCols, vtkSmartPointer<vtkActor> gridActor, const std::vector<const SubstateInfo*>& colorSubstateInfos) = 0;
 
+    /// @brief Enable an axis-aligned 2D slice for a native 3D model.
+    virtual void setNative3DSlice(GridSliceAxis axis, int fixedIndex) = 0;
+
+    /// @brief Return from a native 3D slice to volume rendering.
+    virtual void clearNative3DSlice() = 0;
+
+    /// @brief Return true while a native 3D slice is being rendered.
+    virtual bool isNative3DSliceEnabled() const = 0;
+
+    /// @brief Axis currently held constant by the native 3D slice.
+    virtual GridSliceAxis native3DSliceAxis() const = 0;
+
+    /// @brief Index currently held constant by the native 3D slice.
+    virtual int native3DSliceIndex() const = 0;
+
     /// @brief Draw the visualization using VTK with 3D substate as quad mesh surface.
     virtual void drawWithVTK3DSubstate(int nRows, int nCols, vtkSmartPointer<vtkRenderer> renderer, vtkSmartPointer<vtkActor> gridActor, const std::string& substateFieldName, double minValue, double maxValue, const std::vector<const SubstateInfo*>& colorSubstateInfos) = 0;
 
     /// @brief Refresh the VTK windows with 3D substate quad mesh surface.
     virtual void refreshWindowsVTK3DSubstate(int nRows, int nCols, vtkSmartPointer<vtkActor> gridActor, const std::string& substateFieldName, double minValue, double maxValue, const std::vector<const SubstateInfo*>& colorSubstateInfos) = 0;
+
+    /// @brief Draw a vertical profile through a 2D model visualized as a height field.
+    virtual void drawWithVTK3DSubstateSlice(int nRows,
+                                            int nCols,
+                                            vtkSmartPointer<vtkRenderer> renderer,
+                                            vtkSmartPointer<vtkActor> gridActor,
+                                            const std::string& substateFieldName,
+                                            double minValue,
+                                            double maxValue,
+                                            const std::vector<const SubstateInfo*>& colorSubstateInfos,
+                                            GridSliceAxis fixedAxis,
+                                            int fixedIndex) = 0;
 
     /// @brief Draw flat background plane at Z=0 for 3D visualization.
     virtual void drawFlatSceneBackground(int nRows, int nCols, vtkSmartPointer<vtkRenderer> renderer, vtkSmartPointer<vtkActor> backgroundActor) = 0;

--- a/visualiserProxy/SceneWidgetVisualizerProxy.h
+++ b/visualiserProxy/SceneWidgetVisualizerProxy.h
@@ -99,6 +99,22 @@ public:
     {
         if (p.layerCount() > 1)
         {
+            if (nativeSliceEnabled)
+            {
+                if (nativeVolumeActor)
+                    renderer->RemoveVolume(nativeVolumeActor);
+
+                const ContiguousGridSliceView<Cell> slice(p, nativeSliceAxis, nativeSliceIndex);
+                visualiser.drawWithVTK(slice,
+                                       static_cast<int>(slice.rowCount()),
+                                       static_cast<int>(slice.columnCount()),
+                                       renderer,
+                                       gridActor,
+                                       colorSubstateInfos,
+                                       useCellRendering);
+                return;
+            }
+
             if (!nativeVolumeActor)
                 nativeVolumeActor = vtkSmartPointer<vtkVolume>::New();
             nativeVolumeRenderer = renderer;
@@ -122,6 +138,17 @@ public:
     {
         if (p.layerCount() > 1)
         {
+            if (nativeSliceEnabled)
+            {
+                const ContiguousGridSliceView<Cell> slice(p, nativeSliceAxis, nativeSliceIndex);
+                visualiser.refreshWindowsVTK(slice,
+                                             static_cast<int>(slice.rowCount()),
+                                             static_cast<int>(slice.columnCount()),
+                                             gridActor,
+                                             colorSubstateInfos);
+                return;
+            }
+
             if (!nativeVolumeActor)
                 nativeVolumeActor = vtkSmartPointer<vtkVolume>::New();
             if (nativeVolumeRenderer)
@@ -138,6 +165,51 @@ public:
         visualiser.refreshWindowsVTK(p, nRows, nCols, gridActor, colorSubstateInfos);
     }
 
+    void setNative3DSlice(GridSliceAxis axis, int fixedIndex) override
+    {
+        const auto axisSize = [this, axis]
+        {
+            switch (axis)
+            {
+                case GridSliceAxis::X:
+                    return p.columnCount();
+                case GridSliceAxis::Y:
+                    return p.rowCount();
+                case GridSliceAxis::Z:
+                    return p.layerCount();
+            }
+            return std::size_t{};
+        }();
+
+        if (axisSize == 0)
+            return;
+
+        nativeSliceAxis = axis;
+        nativeSliceIndex = static_cast<std::size_t>(
+            std::clamp(fixedIndex, 0, static_cast<int>(axisSize) - 1));
+        nativeSliceEnabled = true;
+    }
+
+    void clearNative3DSlice() override
+    {
+        nativeSliceEnabled = false;
+    }
+
+    bool isNative3DSliceEnabled() const override
+    {
+        return nativeSliceEnabled;
+    }
+
+    GridSliceAxis native3DSliceAxis() const override
+    {
+        return nativeSliceAxis;
+    }
+
+    int native3DSliceIndex() const override
+    {
+        return static_cast<int>(nativeSliceIndex);
+    }
+
     void drawWithVTK3DSubstate(int nRows, int nCols, vtkSmartPointer<vtkRenderer> renderer, vtkSmartPointer<vtkActor> gridActor, const std::string& substateFieldName, double minValue, double maxValue, const std::vector<const SubstateInfo*>& colorSubstateInfos) override
     {
         visualiser.drawWithVTK3DSubstate(p, nRows, nCols, renderer, gridActor, substateFieldName, minValue, maxValue, colorSubstateInfos);
@@ -146,6 +218,30 @@ public:
     void refreshWindowsVTK3DSubstate(int nRows, int nCols, vtkSmartPointer<vtkActor> gridActor, const std::string& substateFieldName, double minValue, double maxValue, const std::vector<const SubstateInfo*>& colorSubstateInfos) override
     {
         visualiser.refreshWindowsVTK3DSubstate(p, nRows, nCols, gridActor, substateFieldName, minValue, maxValue, colorSubstateInfos);
+    }
+
+    void drawWithVTK3DSubstateSlice(int nRows,
+                                    int nCols,
+                                    vtkSmartPointer<vtkRenderer> renderer,
+                                    vtkSmartPointer<vtkActor> gridActor,
+                                    const std::string& substateFieldName,
+                                    double minValue,
+                                    double maxValue,
+                                    const std::vector<const SubstateInfo*>& colorSubstateInfos,
+                                    GridSliceAxis fixedAxis,
+                                    int fixedIndex) override
+    {
+        visualiser.drawWithVTK3DSubstateSlice(p,
+                                              nRows,
+                                              nCols,
+                                              renderer,
+                                              gridActor,
+                                              substateFieldName,
+                                              minValue,
+                                              maxValue,
+                                              colorSubstateInfos,
+                                              fixedAxis,
+                                              fixedIndex);
     }
 
     void drawFlatSceneBackground(int nRows, int nCols, vtkSmartPointer<vtkRenderer> renderer, vtkSmartPointer<vtkActor> backgroundActor) override
@@ -207,6 +303,19 @@ public:
 
     std::string getCellStringEncoding(int row, int col, const char* details = nullptr) const override
     {
+        if (nativeSliceEnabled && p.layerCount() > 1)
+        {
+            const ContiguousGridSliceView<Cell> slice(p, nativeSliceAxis, nativeSliceIndex);
+            if (row < 0 || col < 0 ||
+                row >= static_cast<int>(slice.rowCount()) ||
+                col >= static_cast<int>(slice.columnCount()))
+            {
+                return {};
+            }
+            return slice[static_cast<std::size_t>(row)][static_cast<std::size_t>(col)]
+                .stringEncoding(details);
+        }
+
         if (row < 0 || col < 0 || row >= static_cast<int>(p.size()))
             return {};
         if (col >= static_cast<int>(p[row].size()))
@@ -224,4 +333,7 @@ private:
     vtkSmartPointer<vtkVolume> nativeVolumeActor;
     vtkSmartPointer<vtkRenderer> nativeVolumeRenderer;
     NodeIndex nodeCountZ = 1;
+    bool nativeSliceEnabled = false;
+    GridSliceAxis nativeSliceAxis = GridSliceAxis::Z;
+    std::size_t nativeSliceIndex = 0;
 };

--- a/visualiserProxy/SceneWidgetVisualizerProxy.h
+++ b/visualiserProxy/SceneWidgetVisualizerProxy.h
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <vector>
+#include <vtkVolume.h>
 #include "ISceneWidgetVisualizer.h"
 #include "data/ModelReader.hpp"
 #include "visualiserProxy/ContiguousGrid.h"
@@ -84,16 +85,55 @@ public:
 
     void readStageStateFromFilesForStep(SettingParameter* sp, Line* lines) override
     {
+        if (p.rowCount() != static_cast<std::size_t>(sp->numberOfRowsY) ||
+            p.columnCount() != static_cast<std::size_t>(sp->numberOfColumnX) ||
+            p.layerCount() != static_cast<std::size_t>(sp->numberOfSlicesZ))
+        {
+            p.resize(sp->numberOfRowsY, sp->numberOfColumnX, sp->numberOfSlicesZ);
+        }
         modelReader.readStageStateFromFilesForStep(p, sp, lines);
     }
 
     void drawWithVTK(int nRows, int nCols, vtkSmartPointer<vtkRenderer> renderer, vtkSmartPointer<vtkActor> gridActor, const std::vector<const SubstateInfo*>& colorSubstateInfos, bool useCellRendering = false) override
     {
+        if (p.layerCount() > 1)
+        {
+            if (!nativeVolumeActor)
+                nativeVolumeActor = vtkSmartPointer<vtkVolume>::New();
+            nativeVolumeRenderer = renderer;
+            renderer->RemoveVolume(nativeVolumeActor);
+            visualiser.drawWithVTK3DVolume(p,
+                                           nRows,
+                                           nCols,
+                                           static_cast<int>(p.layerCount()),
+                                           renderer,
+                                           nativeVolumeActor,
+                                           colorSubstateInfos);
+            return;
+        }
+
+        if (nativeVolumeActor)
+            renderer->RemoveVolume(nativeVolumeActor);
         visualiser.drawWithVTK(p, nRows, nCols, renderer, gridActor, colorSubstateInfos, useCellRendering);
     }
 
     void refreshWindowsVTK(int nRows, int nCols, vtkSmartPointer<vtkActor> gridActor, const std::vector<const SubstateInfo*>& colorSubstateInfos) override
     {
+        if (p.layerCount() > 1)
+        {
+            if (!nativeVolumeActor)
+                nativeVolumeActor = vtkSmartPointer<vtkVolume>::New();
+            if (nativeVolumeRenderer)
+                nativeVolumeRenderer->RemoveVolume(nativeVolumeActor);
+            visualiser.drawWithVTK3DVolume(p,
+                                           nRows,
+                                           nCols,
+                                           static_cast<int>(p.layerCount()),
+                                           nativeVolumeRenderer,
+                                           nativeVolumeActor,
+                                           colorSubstateInfos);
+            return;
+        }
         visualiser.refreshWindowsVTK(p, nRows, nCols, gridActor, colorSubstateInfos);
     }
 
@@ -158,4 +198,6 @@ private:
     Visualizer visualiser;           ///< The visualizer instance for rendering the model
     ModelReader<Cell> modelReader;   ///< The reader for loading and managing model data
     ContiguousGrid<Cell> p;          ///< Temporary contiguous grid storage with a default single layer until std::mdspan is available
+    vtkSmartPointer<vtkVolume> nativeVolumeActor;
+    vtkSmartPointer<vtkRenderer> nativeVolumeRenderer;
 };

--- a/visualiserProxy/SceneWidgetVisualizerProxy.h
+++ b/visualiserProxy/SceneWidgetVisualizerProxy.h
@@ -70,6 +70,7 @@ public:
 
     void prepareStage(int nNodeX, int nNodeY, int nNodeZ = 1) override
     {
+        nodeCountZ = nNodeZ;
         modelReader.prepareStage(nNodeX, nNodeY, nNodeZ);
     }
 
@@ -149,7 +150,8 @@ public:
 
     void drawFlatSceneBackground(int nRows, int nCols, vtkSmartPointer<vtkRenderer> renderer, vtkSmartPointer<vtkActor> backgroundActor) override
     {
-        visualiser.drawFlatSceneBackground(nRows, nCols, renderer, backgroundActor);
+        const double zPosition = p.layerCount() > 1 ? -1.0 : 0.0;
+        visualiser.drawFlatSceneBackground(nRows, nCols, renderer, backgroundActor, zPosition);
     }
 
     void refreshFlatSceneBackground(int nRows, int nCols, vtkSmartPointer<vtkActor> backgroundActor) override
@@ -159,11 +161,32 @@ public:
 
     void drawGridLinesOn3DSurface(int nRows, int nCols, const std::vector<Line>& lines, vtkSmartPointer<vtkRenderer> renderer, vtkSmartPointer<vtkActor> gridLinesActor, const std::string& substateFieldName, double minValue, double maxValue) override
     {
+        if (p.layerCount() > 1)
+        {
+            visualiser.drawGridLinesFor3DVolume(nRows,
+                                                nCols,
+                                                static_cast<int>(p.layerCount()),
+                                                static_cast<int>(nodeCountZ),
+                                                lines,
+                                                renderer,
+                                                gridLinesActor);
+            return;
+        }
         visualiser.drawGridLinesOn3DSurface(p, nRows, nCols, lines, renderer, gridLinesActor, substateFieldName, minValue, maxValue);
     }
 
     void refreshGridLinesOn3DSurface(int nRows, int nCols, const std::vector<Line>& lines, vtkSmartPointer<vtkActor> gridLinesActor, const std::string& substateFieldName, double minValue, double maxValue) override
     {
+        if (p.layerCount() > 1)
+        {
+            visualiser.refreshGridLinesFor3DVolume(nRows,
+                                                   nCols,
+                                                   static_cast<int>(p.layerCount()),
+                                                   static_cast<int>(nodeCountZ),
+                                                   lines,
+                                                   gridLinesActor);
+            return;
+        }
         visualiser.refreshGridLinesOn3DSurface(p, nRows, nCols, lines, gridLinesActor, substateFieldName, minValue, maxValue);
     }
 
@@ -200,4 +223,5 @@ private:
     ContiguousGrid<Cell> p;          ///< Temporary contiguous grid storage with a default single layer until std::mdspan is available
     vtkSmartPointer<vtkVolume> nativeVolumeActor;
     vtkSmartPointer<vtkRenderer> nativeVolumeRenderer;
+    NodeIndex nodeCountZ = 1;
 };

--- a/widgets/CustomInteractorStyle.cpp
+++ b/widgets/CustomInteractorStyle.cpp
@@ -233,6 +233,9 @@ void CustomInteractorStyle::ZoomTowardsCursor(double zoomFactor)
 
 void CustomInteractorStyle::OnLeftButtonDown()
 {
+    if (!m_3dInteractionEnabled)
+        return;
+
     // If Shift is pressed: start custom panning
     if (this->Interactor->GetShiftKey())
     {
@@ -253,6 +256,9 @@ void CustomInteractorStyle::OnLeftButtonDown()
 
 void CustomInteractorStyle::OnLeftButtonUp()
 {
+    if (!m_3dInteractionEnabled)
+        return;
+
     if (m_isPanning)
     {
         m_isPanning = false;
@@ -266,8 +272,35 @@ void CustomInteractorStyle::OnLeftButtonUp()
     }
 }
 
+void CustomInteractorStyle::OnMiddleButtonDown()
+{
+    if (m_3dInteractionEnabled)
+        this->Superclass::OnMiddleButtonDown();
+}
+
+void CustomInteractorStyle::OnMiddleButtonUp()
+{
+    if (m_3dInteractionEnabled)
+        this->Superclass::OnMiddleButtonUp();
+}
+
+void CustomInteractorStyle::OnRightButtonDown()
+{
+    if (m_3dInteractionEnabled)
+        this->Superclass::OnRightButtonDown();
+}
+
+void CustomInteractorStyle::OnRightButtonUp()
+{
+    if (m_3dInteractionEnabled)
+        this->Superclass::OnRightButtonUp();
+}
+
 void CustomInteractorStyle::OnMouseMove()
 {
+    if (!m_3dInteractionEnabled)
+        return;
+
     if (m_isPanning)
     {
         // Custom panning when Shift+Left is held

--- a/widgets/CustomInteractorStyle.h
+++ b/widgets/CustomInteractorStyle.h
@@ -34,6 +34,20 @@ public:
 
     CustomInteractorStyle();
 
+    /** @brief Enable full trackball navigation.
+     *
+     * When disabled (2D mode), only the custom cursor-centered mouse-wheel
+     * zoom remains active. Rotation, pan and right-button dolly are blocked. */
+    void Set3DInteractionEnabled(bool enabled) noexcept
+    {
+        m_3dInteractionEnabled = enabled;
+    }
+
+    [[nodiscard]] bool Get3DInteractionEnabled() const noexcept
+    {
+        return m_3dInteractionEnabled;
+    }
+
     /** @brief Handle mouse wheel forward event (zoom in).
      * 
      * Zooms in towards the cursor position. */
@@ -53,6 +67,11 @@ public:
      * 
      * Stops panning when left button is released. */
     void OnLeftButtonUp() override;
+
+    void OnMiddleButtonDown() override;
+    void OnMiddleButtonUp() override;
+    void OnRightButtonDown() override;
+    void OnRightButtonUp() override;
 
     /** @brief Handle mouse move event during panning.
      * 
@@ -76,6 +95,9 @@ private:
 
     /// @brief Flag indicating if panning is active
     bool m_isPanning = false;
+
+    /// @brief False in 2D mode, where only cursor-centered wheel zoom is allowed.
+    bool m_3dInteractionEnabled = true;
 
     /// @brief Picker used to find world position under cursor
     vtkSmartPointer<vtkCellPicker> m_picker;

--- a/widgets/SceneWidget.cpp
+++ b/widgets/SceneWidget.cpp
@@ -53,8 +53,14 @@ public:
     void readStageStateFromFilesForStep(SettingParameter*, Line*) override {}
     void drawWithVTK(int, int, vtkSmartPointer<vtkRenderer>, vtkSmartPointer<vtkActor>, const std::vector<const SubstateInfo*>&, bool) override {}
     void refreshWindowsVTK(int, int, vtkSmartPointer<vtkActor>, const std::vector<const SubstateInfo*>&) override {}
+    void setNative3DSlice(GridSliceAxis, int) override {}
+    void clearNative3DSlice() override {}
+    bool isNative3DSliceEnabled() const override { return false; }
+    GridSliceAxis native3DSliceAxis() const override { return GridSliceAxis::Z; }
+    int native3DSliceIndex() const override { return 0; }
     void drawWithVTK3DSubstate(int, int, vtkSmartPointer<vtkRenderer>, vtkSmartPointer<vtkActor>, const std::string&, double, double, const std::vector<const SubstateInfo*>&) override {}
     void refreshWindowsVTK3DSubstate(int, int, vtkSmartPointer<vtkActor>, const std::string&, double, double, const std::vector<const SubstateInfo*>&) override {}
+    void drawWithVTK3DSubstateSlice(int, int, vtkSmartPointer<vtkRenderer>, vtkSmartPointer<vtkActor>, const std::string&, double, double, const std::vector<const SubstateInfo*>&, GridSliceAxis, int) override {}
     void drawFlatSceneBackground(int, int, vtkSmartPointer<vtkRenderer>, vtkSmartPointer<vtkActor>) override {}
     void refreshFlatSceneBackground(int, int, vtkSmartPointer<vtkActor>) override {}
     void drawGridLinesOn3DSurface(int, int, const std::vector<Line>&, vtkSmartPointer<vtkRenderer>, vtkSmartPointer<vtkActor>, const std::string&, double, double) override {}
@@ -448,7 +454,8 @@ void SceneWidget::drawVisualizationWithOptional3DSubstate()
 
     if (isNative3DModel())
     {
-        if (flatSceneBackgroundVisible)
+        const bool sliceView = isNative3DSliceView();
+        if (flatSceneBackgroundVisible && !sliceView)
         {
             sceneWidgetVisualizerProxy->drawFlatSceneBackground(settingParameter->numberOfRowsY,
                                                                 settingParameter->numberOfColumnX,
@@ -464,19 +471,22 @@ void SceneWidget::drawVisualizationWithOptional3DSubstate()
                                                 colorSubstateInfos,
                                                 useCellRendering);
 
-        sceneWidgetVisualizerProxy->drawGridLinesOn3DSurface(settingParameter->numberOfRowsY,
-                                                             settingParameter->numberOfColumnX,
-                                                             lines,
-                                                             renderer,
-                                                             gridLinesOnSurfaceActor,
-                                                             {},
-                                                             0.0,
-                                                             1.0);
+        if (!sliceView)
+        {
+            sceneWidgetVisualizerProxy->drawGridLinesOn3DSurface(settingParameter->numberOfRowsY,
+                                                                 settingParameter->numberOfColumnX,
+                                                                 lines,
+                                                                 renderer,
+                                                                 gridLinesOnSurfaceActor,
+                                                                 {},
+                                                                 0.0,
+                                                                 1.0);
+        }
 
         if (actorBuildLine)
             actorBuildLine->SetVisibility(false);
         if (gridLinesOnSurfaceActor)
-            gridLinesOnSurfaceActor->SetVisibility(gridLinesVisible);
+            gridLinesOnSurfaceActor->SetVisibility(!sliceView && gridLinesVisible);
 
         updateCameraPivotFromBounds();
         return;
@@ -490,6 +500,32 @@ void SceneWidget::drawVisualizationWithOptional3DSubstate()
         const auto& substateInfo = settingParameter->substateInfo[activeSubstateFor3D];
         if (! std::isnan(substateInfo.minValue) && ! std::isnan(substateInfo.maxValue))
         {
+            if (substateSliceEnabled)
+            {
+                const auto colorSubstateInfos = getColorSubstateInfos();
+                sceneWidgetVisualizerProxy->drawWithVTK3DSubstateSlice(
+                    settingParameter->numberOfRowsY,
+                    settingParameter->numberOfColumnX,
+                    renderer,
+                    gridActor,
+                    activeSubstateFor3D,
+                    substateInfo.minValue,
+                    substateInfo.maxValue,
+                    colorSubstateInfos,
+                    substateSliceAxis,
+                    substateSliceIndex);
+
+                if (backgroundActor)
+                    backgroundActor->SetVisibility(false);
+                if (actorBuildLine)
+                    actorBuildLine->SetVisibility(false);
+                if (gridLinesOnSurfaceActor)
+                    gridLinesOnSurfaceActor->SetVisibility(false);
+
+                updateCameraPivotFromBounds();
+                return;
+            }
+
             // Clear old background actor to remove any 2D artifacts
             if (backgroundActor && renderer)
             {
@@ -570,6 +606,16 @@ void SceneWidget::refreshVisualizationWithOptional3DSubstate()
 {
     if (isNative3DModel())
     {
+        if (isNative3DSliceView())
+        {
+            // Rebuild instead of only replacing the lookup table: changing the
+            // selected plane can also change its row/column dimensions.
+            drawVisualizationWithOptional3DSubstate();
+            update2DRulerAxesBounds();
+            triggerRenderUpdate();
+            return;
+        }
+
         if (flatSceneBackgroundVisible && backgroundActor && backgroundActor->GetMapper())
         {
             sceneWidgetVisualizerProxy->refreshFlatSceneBackground(settingParameter->numberOfRowsY,
@@ -605,6 +651,14 @@ void SceneWidget::refreshVisualizationWithOptional3DSubstate()
         const auto& substateInfo = settingParameter->substateInfo[activeSubstateFor3D];
         if (! std::isnan(substateInfo.minValue) && ! std::isnan(substateInfo.maxValue))
         {
+            if (substateSliceEnabled)
+            {
+                drawVisualizationWithOptional3DSubstate();
+                update2DRulerAxesBounds();
+                triggerRenderUpdate();
+                return;
+            }
+
             // Refresh flat background scene if enabled
             if (flatSceneBackgroundVisible && backgroundActor && backgroundActor->GetMapper())
             {
@@ -876,6 +930,37 @@ void SceneWidget::update2DRulerAxesBounds()
 
     std::cout << "Ruler axes updated: X=[" << bounds[0] << ", " << bounds[1]
               << "], Y=[" << bounds[2] << ", " << bounds[3] << "]" << std::endl;
+}
+
+void SceneWidget::update2DRulerAxisTitles()
+{
+    const char* horizontalAxis = "X";
+    const char* verticalAxis = "Y";
+
+    if (isNative3DSliceView())
+    {
+        switch (sceneWidgetVisualizerProxy->native3DSliceAxis())
+        {
+            case GridSliceAxis::X:
+                horizontalAxis = "Y";
+                verticalAxis = "Z";
+                break;
+            case GridSliceAxis::Y:
+                horizontalAxis = "X";
+                verticalAxis = "Z";
+                break;
+            case GridSliceAxis::Z:
+                break;
+        }
+    }
+    else if (substateSliceEnabled)
+    {
+        horizontalAxis = substateSliceAxis == GridSliceAxis::Y ? "X" : "Y";
+        verticalAxis = activeSubstateFor3D.c_str();
+    }
+
+    rulerAxisX->SetTitle(horizontalAxis);
+    rulerAxisY->SetTitle(verticalAxis);
 }
 
 void SceneWidget::connectKeyboardCallback()
@@ -1237,6 +1322,60 @@ void SceneWidget::updateToolTip(const QPoint& lastMousePos)
     if (! renderer || ! renderWindow())
         return;
 
+    if (isCrossSectionView() && isWorldPositionInGrid(m_lastWorldPos.data()))
+    {
+        int planeRow = 0;
+        int planeColumn = 0;
+        if (convertWorldToGridCoordinates(m_lastWorldPos.data(), planeRow, planeColumn))
+        {
+            if (substateSliceEnabled)
+            {
+                const int x = substateSliceAxis == GridSliceAxis::Y
+                    ? planeColumn
+                    : substateSliceIndex;
+                const int y = substateSliceAxis == GridSliceAxis::Y
+                    ? substateSliceIndex
+                    : planeRow;
+                QString tooltipText =
+                    QString("Cell Coordinates: (X=%1, Y=%2)").arg(x).arg(y);
+                tooltipText += cellValueAtThisPositionAsText();
+                QToolTip::showText(mapToGlobal(lastMousePos),
+                                   tooltipText,
+                                   this,
+                                   QRect(lastMousePos, QSize(1, 1)),
+                                   0);
+                return;
+            }
+
+            int x = planeColumn;
+            int y = planeRow;
+            int z = sceneWidgetVisualizerProxy->native3DSliceIndex();
+            switch (sceneWidgetVisualizerProxy->native3DSliceAxis())
+            {
+                case GridSliceAxis::X:
+                    x = sceneWidgetVisualizerProxy->native3DSliceIndex();
+                    y = planeColumn;
+                    z = settingParameter->numberOfSlicesZ - 1 - planeRow;
+                    break;
+                case GridSliceAxis::Y:
+                    y = sceneWidgetVisualizerProxy->native3DSliceIndex();
+                    z = settingParameter->numberOfSlicesZ - 1 - planeRow;
+                    break;
+                case GridSliceAxis::Z:
+                    break;
+            }
+            QString tooltipText =
+                QString("Cell Coordinates: (X=%1, Y=%2, Z=%3)").arg(x).arg(y).arg(z);
+            tooltipText += cellValueAtThisPositionAsText();
+            QToolTip::showText(mapToGlobal(lastMousePos),
+                               tooltipText,
+                               this,
+                               QRect(lastMousePos, QSize(1, 1)),
+                               0);
+            return;
+        }
+    }
+
     // m_lastMousePos is already in Qt coordinates (origin: top-left)
     // m_lastWorldPos is set by the VTK callback (picker or DisplayToWorld fallback)
 
@@ -1408,6 +1547,8 @@ void SceneWidget::clearScene()
 
     // Clear stage data
     sceneWidgetVisualizerProxy->clearStage();
+    sceneWidgetVisualizerProxy->clearNative3DSlice();
+    substateSliceEnabled = false;
 
     // Reset setting parameters to avoid stale data
     settingParameter = std::make_unique<SettingParameter>();
@@ -1468,7 +1609,7 @@ void SceneWidget::refreshStepNumberTextColorFromSettings()
 
 void SceneWidget::setViewMode2D()
 {
-    if (isNative3DModel())
+    if (isNative3DModel() && !isNative3DSliceView())
     {
         std::cerr << "2D view is unavailable for a native 3D model." << std::endl;
         return;
@@ -1483,7 +1624,8 @@ void SceneWidget::setViewMode2D()
     currentViewMode = ViewMode::Mode2D;
     
     // Disable 3D substate visualization when switching to 2D mode
-    activeSubstateFor3D.clear();
+    if (!substateSliceEnabled)
+        activeSubstateFor3D.clear();
     
     // In 2D mode, flat scene background is always visible (it's the 2D visualization itself)
     flatSceneBackgroundVisible = true;
@@ -1530,9 +1672,11 @@ void SceneWidget::setViewMode2D()
 
     // Setup 2D ruler axes (bounds will be updated when data is loaded)
     setup2DRulerAxes();
+    update2DRulerAxisTitles();
 
     // Rebuild grid lines (they were removed when switching to 3D substate)
-    if (settingParameter && sceneWidgetVisualizerProxy && !lines.empty())
+    if (settingParameter && sceneWidgetVisualizerProxy && !lines.empty() &&
+        !isNative3DModel() && !substateSliceEnabled)
     {
         sceneWidgetVisualizerProxy->getVisualizer().buildLoadBalanceLine(lines,
                                                                          settingParameter->numberOfRowsY + 1,
@@ -1601,6 +1745,117 @@ bool SceneWidget::isNative3DModel() const
     return settingParameter && settingParameter->numberOfSlicesZ > 1;
 }
 
+bool SceneWidget::isNative3DSliceView() const
+{
+    return isNative3DModel() &&
+           sceneWidgetVisualizerProxy &&
+           sceneWidgetVisualizerProxy->isNative3DSliceEnabled();
+}
+
+bool SceneWidget::is3DSubstateSurface() const
+{
+    if (!settingParameter || isNative3DModel() || activeSubstateFor3D.empty())
+        return false;
+
+    const auto info = settingParameter->substateInfo.find(activeSubstateFor3D);
+    return info != settingParameter->substateInfo.end() &&
+           !std::isnan(info->second.minValue) &&
+           !std::isnan(info->second.maxValue) &&
+           info->second.minValue < info->second.maxValue;
+}
+
+bool SceneWidget::hasSliceable3DView() const
+{
+    return isNative3DModel() || is3DSubstateSurface();
+}
+
+bool SceneWidget::isCrossSectionView() const
+{
+    return isNative3DSliceView() || substateSliceEnabled;
+}
+
+void SceneWidget::setNative3DSlice(GridSliceAxis axis, int fixedIndex)
+{
+    if (!isNative3DModel() || !sceneWidgetVisualizerProxy)
+        return;
+
+    const bool planeChanged =
+        !isNative3DSliceView() ||
+        sceneWidgetVisualizerProxy->native3DSliceAxis() != axis;
+
+    sceneWidgetVisualizerProxy->setNative3DSlice(axis, fixedIndex);
+
+    if (planeChanged || currentViewMode != ViewMode::Mode2D)
+    {
+        setViewMode2D();
+        return;
+    }
+
+    drawVisualizationWithOptional3DSubstate();
+    update2DRulerAxisTitles();
+    update2DRulerAxesBounds();
+    updateCameraPivotFromBounds();
+    triggerRenderUpdate();
+}
+
+void SceneWidget::setNative3DVolumeView()
+{
+    if (!isNative3DModel() || !sceneWidgetVisualizerProxy)
+        return;
+
+    sceneWidgetVisualizerProxy->clearNative3DSlice();
+    drawVisualizationWithOptional3DSubstate();
+    setViewMode3D();
+    updateCameraPivotFromBounds();
+    applyCameraAngles();
+}
+
+void SceneWidget::setSubstate3DSlice(GridSliceAxis axis, int fixedIndex)
+{
+    if (!is3DSubstateSurface() ||
+        (axis != GridSliceAxis::X && axis != GridSliceAxis::Y))
+    {
+        return;
+    }
+
+    const bool planeChanged = !substateSliceEnabled || substateSliceAxis != axis;
+    substateSliceEnabled = true;
+    substateSliceAxis = axis;
+    substateSliceIndex = axis == GridSliceAxis::Y
+        ? std::clamp(fixedIndex, 0, settingParameter->numberOfRowsY - 1)
+        : std::clamp(fixedIndex, 0, settingParameter->numberOfColumnX - 1);
+
+    if (planeChanged || currentViewMode != ViewMode::Mode2D)
+    {
+        setViewMode2D();
+        return;
+    }
+
+    drawVisualizationWithOptional3DSubstate();
+    update2DRulerAxisTitles();
+    update2DRulerAxesBounds();
+    updateCameraPivotFromBounds();
+    triggerRenderUpdate();
+}
+
+void SceneWidget::clearCrossSection()
+{
+    if (isNative3DSliceView())
+    {
+        setNative3DVolumeView();
+        return;
+    }
+
+    if (!substateSliceEnabled)
+        return;
+
+    substateSliceEnabled = false;
+    drawVisualizationWithOptional3DSubstate();
+    setViewMode3D();
+    updateCameraPivotFromBounds();
+    applyCameraAngles();
+}
+
 void SceneWidget::setAxesWidgetVisible(bool visible)
 {
     if (axesWidget)
@@ -1640,6 +1895,8 @@ void SceneWidget::setUseCellRendering(bool useCellRenderingMode)
 
 void SceneWidget::setActiveSubstateFor3D(const std::string& fieldName)
 {
+    if (fieldName.empty())
+        substateSliceEnabled = false;
     activeSubstateFor3D = fieldName;
 }
 
@@ -1755,8 +2012,35 @@ bool SceneWidget::convertWorldToGridCoordinates(const double worldPos[3], int& o
     if (sceneWidth <= 0 || sceneHeight <= 0)
         return false;
 
-    const double cellWidth = sceneWidth / settingParameter->numberOfColumnX;
-    const double cellHeight = sceneHeight / settingParameter->numberOfRowsY;
+    if (substateSliceEnabled)
+    {
+        const int sampleCount = substateSliceAxis == GridSliceAxis::Y
+            ? settingParameter->numberOfColumnX
+            : settingParameter->numberOfRowsY;
+        int sample = static_cast<int>(
+            ((worldPos[0] - bounds[0]) / sceneWidth) * sampleCount);
+        sample = std::clamp(sample, 0, sampleCount - 1);
+
+        if (substateSliceAxis == GridSliceAxis::Y)
+        {
+            outRow = substateSliceIndex;
+            outCol = sample;
+        }
+        else
+        {
+            outRow = sample;
+            outCol = substateSliceIndex;
+        }
+        return true;
+    }
+
+    const int columnCount = displayedColumnCount();
+    const int rowCount = displayedRowCount();
+    if (columnCount <= 0 || rowCount <= 0)
+        return false;
+
+    const double cellWidth = sceneWidth / columnCount;
+    const double cellHeight = sceneHeight / rowCount;
 
     // Convert world position to grid indices
     // Points are positioned with Y inverted: (nRows - 1 - row)
@@ -1765,15 +2049,39 @@ bool SceneWidget::convertWorldToGridCoordinates(const double worldPos[3], int& o
     int row = static_cast<int>((worldPos[1] - bounds[2]) / cellHeight);
     
     // Invert row to match the inverted Y coordinates used in visualization
-    row = settingParameter->numberOfRowsY - 1 - row;
+    row = rowCount - 1 - row;
 
     // Clamp to valid range
-    col = std::max(0, std::min(col, settingParameter->numberOfColumnX - 1));
-    row = std::max(0, std::min(row, settingParameter->numberOfRowsY - 1));
+    col = std::max(0, std::min(col, columnCount - 1));
+    row = std::max(0, std::min(row, rowCount - 1));
 
     outRow = row;
     outCol = col;
     return true;
+}
+
+int SceneWidget::displayedRowCount() const
+{
+    if (!settingParameter)
+        return 0;
+    if (!isNative3DSliceView())
+        return settingParameter->numberOfRowsY;
+
+    return sceneWidgetVisualizerProxy->native3DSliceAxis() == GridSliceAxis::Z
+        ? settingParameter->numberOfRowsY
+        : settingParameter->numberOfSlicesZ;
+}
+
+int SceneWidget::displayedColumnCount() const
+{
+    if (!settingParameter)
+        return 0;
+    if (!isNative3DSliceView())
+        return settingParameter->numberOfColumnX;
+
+    return sceneWidgetVisualizerProxy->native3DSliceAxis() == GridSliceAxis::X
+        ? settingParameter->numberOfRowsY
+        : settingParameter->numberOfColumnX;
 }
 
 bool SceneWidget::isWorldPositionInGrid(const double worldPos[3]) const
@@ -1808,9 +2116,32 @@ void SceneWidget::setupInteractorStyleWithWaitCursor()
 
 void SceneWidget::applyGridLinesSettings()
 {
+    const bool isNativeModel = settingParameter && settingParameter->numberOfSlicesZ > 1;
+    const bool isNative3D = isNativeModel && !isNative3DSliceView();
+
+    // The existing load-balancing line data describes XY partitions only.
+    // Do not display it on XZ/YZ slices (or stale over an XY slice) until a
+    // plane-specific node-boundary representation is built.
+    if (isNativeModel && isNative3DSliceView())
+    {
+        if (actorBuildLine)
+            actorBuildLine->SetVisibility(false);
+        if (gridLinesOnSurfaceActor)
+            gridLinesOnSurfaceActor->SetVisibility(false);
+        return;
+    }
+
+    if (substateSliceEnabled)
+    {
+        if (actorBuildLine)
+            actorBuildLine->SetVisibility(false);
+        if (gridLinesOnSurfaceActor)
+            gridLinesOnSurfaceActor->SetVisibility(false);
+        return;
+    }
+
     // Native volumes never use the flat XY node overlay. The established
     // 2D "substate as altitude" mode keeps its surface-line behavior.
-    const bool isNative3D = settingParameter && settingParameter->numberOfSlicesZ > 1;
     const bool isSubstateSurface =
         !isNative3D &&
         settingParameter &&

--- a/widgets/SceneWidget.cpp
+++ b/widgets/SceneWidget.cpp
@@ -380,6 +380,42 @@ void SceneWidget::drawVisualizationWithOptional3DSubstate()
     {
         renderer->RemoveActor(gridLinesOnSurfaceActor);
     }
+
+    if (isNative3DModel())
+    {
+        if (flatSceneBackgroundVisible)
+        {
+            sceneWidgetVisualizerProxy->drawFlatSceneBackground(settingParameter->numberOfRowsY,
+                                                                settingParameter->numberOfColumnX,
+                                                                renderer,
+                                                                backgroundActor);
+        }
+
+        const auto colorSubstateInfos = getColorSubstateInfos();
+        sceneWidgetVisualizerProxy->drawWithVTK(settingParameter->numberOfRowsY,
+                                                settingParameter->numberOfColumnX,
+                                                renderer,
+                                                gridActor,
+                                                colorSubstateInfos,
+                                                useCellRendering);
+
+        sceneWidgetVisualizerProxy->drawGridLinesOn3DSurface(settingParameter->numberOfRowsY,
+                                                             settingParameter->numberOfColumnX,
+                                                             lines,
+                                                             renderer,
+                                                             gridLinesOnSurfaceActor,
+                                                             {},
+                                                             0.0,
+                                                             1.0);
+
+        if (actorBuildLine)
+            actorBuildLine->SetVisibility(false);
+        if (gridLinesOnSurfaceActor)
+            gridLinesOnSurfaceActor->SetVisibility(gridLinesVisible);
+
+        updateCameraPivotFromBounds();
+        return;
+    }
     
     // Check if we should use 3D substate visualization
     if (settingParameter->numberOfSlicesZ <= 1 &&
@@ -467,6 +503,35 @@ std::vector<const SubstateInfo*> SceneWidget::getColorSubstateInfos()
 
 void SceneWidget::refreshVisualizationWithOptional3DSubstate()
 {
+    if (isNative3DModel())
+    {
+        if (flatSceneBackgroundVisible && backgroundActor && backgroundActor->GetMapper())
+        {
+            sceneWidgetVisualizerProxy->refreshFlatSceneBackground(settingParameter->numberOfRowsY,
+                                                                   settingParameter->numberOfColumnX,
+                                                                   backgroundActor);
+        }
+
+        const auto colorSubstateInfos = getColorSubstateInfos();
+        sceneWidgetVisualizerProxy->refreshWindowsVTK(settingParameter->numberOfRowsY,
+                                                      settingParameter->numberOfColumnX,
+                                                      gridActor,
+                                                      colorSubstateInfos);
+        sceneWidgetVisualizerProxy->refreshGridLinesOn3DSurface(settingParameter->numberOfRowsY,
+                                                                settingParameter->numberOfColumnX,
+                                                                lines,
+                                                                gridLinesOnSurfaceActor,
+                                                                {},
+                                                                0.0,
+                                                                1.0);
+
+        if (gridLinesOnSurfaceActor)
+            gridLinesOnSurfaceActor->SetVisibility(gridLinesVisible);
+
+        updateCameraPivotFromBounds();
+        return;
+    }
+
     // Check if we should use 3D substate visualization
     if (settingParameter->numberOfSlicesZ <= 1 &&
         !activeSubstateFor3D.empty() &&
@@ -1345,6 +1410,12 @@ void SceneWidget::refreshStepNumberTextColorFromSettings()
 
 void SceneWidget::setViewMode2D()
 {
+    if (isNative3DModel())
+    {
+        std::cerr << "2D view is unavailable for a native 3D model." << std::endl;
+        return;
+    }
+
     if (! interactor())
         return;
 
@@ -1458,7 +1529,7 @@ void SceneWidget::setViewMode3D()
     rulerAxisY->SetVisibility(false);
 
     // Clear any 2D background artifacts before rendering 3D scene
-    if (backgroundActor && renderer)
+    if (!isNative3DModel() && backgroundActor && renderer)
     {
         renderer->RemoveActor(backgroundActor);
         backgroundActor = vtkSmartPointer<vtkActor>::New();
@@ -1467,6 +1538,11 @@ void SceneWidget::setViewMode3D()
     std::cout << "Switched to 3D view mode" << std::endl;
     
     // Cursor restored automatically by WaitCursorGuard destructor
+}
+
+bool SceneWidget::isNative3DModel() const
+{
+    return settingParameter && settingParameter->numberOfSlicesZ > 1;
 }
 
 void SceneWidget::setAxesWidgetVisible(bool visible)

--- a/widgets/SceneWidget.cpp
+++ b/widgets/SceneWidget.cpp
@@ -965,19 +965,22 @@ void SceneWidget::cameraCallbackFunction(vtkObject* caller, long unsigned int ev
     if (! self)
         return;
 
-    // Only emit signal in 3D mode (user finished rotating the camera)
+    // Synchronize only in 3D mode; 2D interaction has no rotation controls.
     if (self->currentViewMode == ViewMode::Mode3D && self->renderer)
     {
         vtkCamera* camera = self->renderer->GetActiveCamera();
         if (camera)
         {
             const CameraEulerAngles angles = cameraEulerFromVtk(*camera);
+            double focalPoint[3];
+            camera->GetFocalPoint(focalPoint);
 
             // Store the actual VTK orientation. The Qt side blocks slider signals
             // while displaying these values, so this cannot feed back into VTK.
             self->cameraRoll = angles.roll;
             self->cameraPitch = angles.pitch;
             self->cameraYaw = angles.yaw;
+            self->cameraPivot = { focalPoint[0], focalPoint[1], focalPoint[2] };
 
             emit self->cameraOrientationChanged(angles.roll, angles.pitch, angles.yaw);
         }
@@ -1798,6 +1801,7 @@ void SceneWidget::setupInteractorStyleWithWaitCursor()
     // Features: Ray-plane zoom (zoom towards cursor), wait cursor, Shift+Drag panning
     // Cost: ~5% overhead due to ray-plane calculations
     vtkNew<CustomInteractorStyle> style;
+    style->Set3DInteractionEnabled(currentViewMode == ViewMode::Mode3D);
     interactor()->SetInteractorStyle(style);
     connectCameraCallback();
 }

--- a/widgets/SceneWidget.cpp
+++ b/widgets/SceneWidget.cpp
@@ -141,6 +141,129 @@ vtkColor3d toVtkColor(QColor color)
         color.blueF()
     };
 }
+
+struct CameraEulerAngles
+{
+    double roll = 0.0;  // X
+    double pitch = 0.0; // Y
+    double yaw = 0.0;   // Z
+};
+
+struct CameraBasis
+{
+    std::array<double, 3> right;
+    std::array<double, 3> up;
+    std::array<double, 3> backward;
+};
+
+constexpr double radiansToDegrees(double radians)
+{
+    return radians * 180.0 / vtkMath::Pi();
+}
+
+constexpr double degreesToRadians(double degrees)
+{
+    return degrees * vtkMath::Pi() / 180.0;
+}
+
+/** Build R = Rz(yaw) * Ry(pitch) * Rx(roll).
+ *
+ * Its columns are the camera's right, up and backward vectors, matching the
+ * baseline VTK camera (right=+X, up=+Y, position direction=+Z). */
+CameraBasis cameraBasisFromEuler(const CameraEulerAngles& angles)
+{
+    const double x = degreesToRadians(angles.roll);
+    const double y = degreesToRadians(angles.pitch);
+    const double z = degreesToRadians(angles.yaw);
+
+    const double cx = std::cos(x);
+    const double sx = std::sin(x);
+    const double cy = std::cos(y);
+    const double sy = std::sin(y);
+    const double cz = std::cos(z);
+    const double sz = std::sin(z);
+
+    return CameraBasis{
+        .right = {
+            cz * cy,
+            sz * cy,
+            -sy
+        },
+        .up = {
+            cz * sy * sx - sz * cx,
+            sz * sy * sx + cz * cx,
+            cy * sx
+        },
+        .backward = {
+            cz * sy * cx + sz * sx,
+            sz * sy * cx - cz * sx,
+            cy * cx
+        }
+    };
+}
+
+CameraEulerAngles cameraEulerFromVtk(vtkCamera& camera)
+{
+    double position[3];
+    double focalPoint[3];
+    double viewUp[3];
+    camera.GetPosition(position);
+    camera.GetFocalPoint(focalPoint);
+    camera.GetViewUp(viewUp);
+
+    double backward[3] = {
+        position[0] - focalPoint[0],
+        position[1] - focalPoint[1],
+        position[2] - focalPoint[2]
+    };
+    if (vtkMath::Normalize(backward) == 0.0)
+        return {};
+
+    // Gram-Schmidt removes numerical drift accumulated by the trackball.
+    const double upProjection = vtkMath::Dot(viewUp, backward);
+    double up[3] = {
+        viewUp[0] - upProjection * backward[0],
+        viewUp[1] - upProjection * backward[1],
+        viewUp[2] - upProjection * backward[2]
+    };
+    if (vtkMath::Normalize(up) == 0.0)
+        return {};
+
+    double right[3];
+    vtkMath::Cross(up, backward, right);
+    vtkMath::Normalize(right);
+    vtkMath::Cross(backward, right, up);
+    vtkMath::Normalize(up);
+
+    // Matrix columns are [right, up, backward]. Decompose the same
+    // Rz * Ry * Rx convention used by cameraBasisFromEuler().
+    const double r00 = right[0];
+    const double r10 = right[1];
+    const double r20 = right[2];
+    const double r01 = up[0];
+    const double r11 = up[1];
+    const double r21 = up[2];
+    const double r22 = backward[2];
+
+    CameraEulerAngles result;
+    result.pitch = radiansToDegrees(std::asin(std::clamp(-r20, -1.0, 1.0)));
+
+    const double cosPitch = std::cos(degreesToRadians(result.pitch));
+    if (std::abs(cosPitch) > 1e-7)
+    {
+        result.roll = radiansToDegrees(std::atan2(r21, r22));
+        result.yaw = radiansToDegrees(std::atan2(r10, r00));
+    }
+    else
+    {
+        // At gimbal lock Roll and Yaw are not independently observable.
+        // Keep the canonical solution Roll=0 and encode rotation in Yaw.
+        result.roll = 0.0;
+        result.yaw = radiansToDegrees(std::atan2(-r01, r11));
+    }
+
+    return result;
+}
 } // namespace
 
 
@@ -177,17 +300,6 @@ void SceneWidget::triggerRenderUpdate()
 
 void SceneWidget::applyCameraAngles()
 {
-    // Temporarily disable VTK warnings.
-    //
-    // Reason:
-    // When the camera elevation approaches ±90 degrees, the view-up vector becomes
-    // nearly parallel to the view-plane normal. VTK interprets this as an invalid
-    // camera configuration and emits warnings such as:
-    //   "Resetting view-up since view plane normal is parallel"
-    //
-    // These warnings normally occur during ResetCamera(), which internally adjusts
-    // the camera to maintain a valid orientation. Since we intentionally allow
-    // near-vertical camera angles, these warnings are expected and not useful here.
     bool oldWarningState = vtkObject::GetGlobalWarningDisplay();
     vtkObject::GlobalWarningDisplayOff();
 
@@ -198,34 +310,21 @@ void SceneWidget::applyCameraAngles()
         return;
     }
 
-    // Reset camera to a known baseline orientation
-    camera->SetPosition(0, 0, 1);
-    camera->SetFocalPoint(0, 0, 0);
-    camera->SetViewUp(0, 1, 0);
+    const CameraBasis basis = cameraBasisFromEuler({
+        .roll = cameraRoll,
+        .pitch = std::clamp(cameraPitch, -90.0, 90.0),
+        .yaw = cameraYaw
+    });
 
-    // Apply azimuth rotation (horizontal)
-    camera->Azimuth(cameraAzimuth);
-
-    // Clamp elevation to avoid exactly ±90° and prevent singularities
-    double clampedElevation = std::clamp(cameraElevation, -89.9, 89.9);
-    camera->Elevation(clampedElevation);
-
-    // Apply roll rotation (around Y axis)
-    camera->Roll(cameraRoll);
-
-    // Apply pitch rotation (around Z axis) with clamping to avoid gimbal lock
-    double clampedPitch = std::clamp(cameraPitch, -89.9, 89.9);
-    camera->Pitch(clampedPitch);
-
-    // Apply yaw rotation (around X axis)
-    camera->Yaw(cameraYaw);
-
-    // Recompute camera bounds for the current renderer
+    camera->SetPosition(cameraPivot[0] + basis.backward[0],
+                        cameraPivot[1] + basis.backward[1],
+                        cameraPivot[2] + basis.backward[2]);
+    camera->SetFocalPoint(cameraPivot.data());
+    camera->SetViewUp(basis.up.data());
+    camera->OrthogonalizeViewUp();
     renderer->ResetCamera();
 
     triggerRenderUpdate();
-
-    // Restore previous warning state
     vtkObject::SetGlobalWarningDisplay(oldWarningState);
 }
 
@@ -235,59 +334,25 @@ void SceneWidget::applyCameraAnglesPreservingZoom()
     if (! camera)
         return;
 
-    double originalPosition[3];
-    camera->GetPosition(originalPosition);
-
-    const double pivot[3] = {
-        cameraPivot[0],
-        cameraPivot[1],
-        cameraPivot[2]
-    };
-
-    double vectorFromPivot[3] = {
-        originalPosition[0] - pivot[0],
-        originalPosition[1] - pivot[1],
-        originalPosition[2] - pivot[2]
-    };
-
-    double distance = vtkMath::Norm(vectorFromPivot);
+    double distance = camera->GetDistance();
     if (distance < 1e-3)
-    {
         distance = 1.0;
-    }
 
     bool oldWarningState = vtkObject::GetGlobalWarningDisplay();
     vtkObject::GlobalWarningDisplayOff();
 
-    camera->SetPosition(0.0, 0.0, distance);
-    camera->SetFocalPoint(0.0, 0.0, 0.0);
-    camera->SetViewUp(0.0, 1.0, 0.0);
+    const CameraBasis basis = cameraBasisFromEuler({
+        .roll = cameraRoll,
+        .pitch = std::clamp(cameraPitch, -90.0, 90.0),
+        .yaw = cameraYaw
+    });
 
-    camera->Azimuth(cameraAzimuth);
-    const double clampedElevation = std::clamp(cameraElevation, -89.9, 89.9);
-    camera->Elevation(clampedElevation);
-    camera->Roll(cameraRoll);
-    
-    // Clamp pitch to avoid gimbal lock and flipping at ±90 degrees
-    const double clampedPitch = std::clamp(cameraPitch, -89.9, 89.9);
-    camera->Pitch(clampedPitch);
-    camera->Yaw(cameraYaw);
-
-    double rotatedPosition[3];
-    double rotatedFocal[3];
-    camera->GetPosition(rotatedPosition);
-    camera->GetFocalPoint(rotatedFocal);
-
-    const double translation[3] = {
-        pivot[0] - rotatedFocal[0],
-        pivot[1] - rotatedFocal[1],
-        pivot[2] - rotatedFocal[2]
-    };
-
-    camera->SetPosition(rotatedPosition[0] + translation[0],
-                        rotatedPosition[1] + translation[1],
-                        rotatedPosition[2] + translation[2]);
-    camera->SetFocalPoint(pivot[0], pivot[1], pivot[2]);
+    camera->SetPosition(cameraPivot[0] + distance * basis.backward[0],
+                        cameraPivot[1] + distance * basis.backward[1],
+                        cameraPivot[2] + distance * basis.backward[2]);
+    camera->SetFocalPoint(cameraPivot.data());
+    camera->SetViewUp(basis.up.data());
+    camera->OrthogonalizeViewUp();
 
     renderer->ResetCameraClippingRange();
     triggerRenderUpdate();
@@ -718,7 +783,6 @@ void SceneWidget::setupVtkScene()
 
     connectKeyboardCallback();
     connectMouseCallback();
-    connectCameraCallback();
 }
 
 void SceneWidget::setupAxesWidget()
@@ -824,15 +888,16 @@ void SceneWidget::connectKeyboardCallback()
 
 void SceneWidget::connectCameraCallback()
 {
-    if (! interactor())
+    if (!interactor() || !interactor()->GetInteractorStyle())
         return;
 
-    // Use EndInteractionEvent instead of camera ModifiedEvent
-    // This is only called when user finishes rotating (releases mouse button)
+    // Interaction events are emitted by vtkInteractorStyle, not by the render
+    // window interactor itself. Listen both during dragging and on release.
     vtkNew<vtkCallbackCommand> cameraCallback;
     cameraCallback->SetCallback(SceneWidget::cameraCallbackFunction);
     cameraCallback->SetClientData(this);
-    interactor()->AddObserver(vtkCommand::EndInteractionEvent, cameraCallback);
+    interactor()->GetInteractorStyle()->AddObserver(vtkCommand::InteractionEvent, cameraCallback);
+    interactor()->GetInteractorStyle()->AddObserver(vtkCommand::EndInteractionEvent, cameraCallback);
 }
 
 void SceneWidget::keypressCallbackFunction(vtkObject* caller, long unsigned int eventId, void* clientData, void* callData)
@@ -906,25 +971,15 @@ void SceneWidget::cameraCallbackFunction(vtkObject* caller, long unsigned int ev
         vtkCamera* camera = self->renderer->GetActiveCamera();
         if (camera)
         {
-            // Get actual camera orientation from VTK
-            const double* position = camera->GetPosition();
-            const double* focalPoint = camera->GetFocalPoint();
+            const CameraEulerAngles angles = cameraEulerFromVtk(*camera);
 
-            // Calculate azimuth and elevation from camera position
-            double dx = position[0] - focalPoint[0];
-            double dy = position[1] - focalPoint[1];
-            double dz = position[2] - focalPoint[2];
+            // Store the actual VTK orientation. The Qt side blocks slider signals
+            // while displaying these values, so this cannot feed back into VTK.
+            self->cameraRoll = angles.roll;
+            self->cameraPitch = angles.pitch;
+            self->cameraYaw = angles.yaw;
 
-            double azimuth = std::atan2(dy, dx) * 180.0 / vtkMath::Pi();
-            double elevation = std::atan2(dz, std::sqrt(dx * dx + dy * dy)) * 180.0 / vtkMath::Pi();
-
-            // Update internal state
-            self->cameraAzimuth = azimuth;
-            self->cameraElevation = elevation;
-            // Note: Roll, Pitch, and Yaw are not extracted from VTK camera here, they're maintained separately
-
-            // Emit signal with actual values
-            emit self->cameraOrientationChanged(azimuth, elevation, self->cameraRoll, self->cameraPitch, self->cameraYaw);
+            emit self->cameraOrientationChanged(angles.roll, angles.pitch, angles.yaw);
         }
     }
 }
@@ -1448,8 +1503,6 @@ void SceneWidget::setViewMode2D()
     setupInteractorStyleWithWaitCursor();
 
     // Reset camera angles
-    cameraAzimuth = {};
-    cameraElevation = {};
     cameraRoll = {};
     cameraPitch = {};
     cameraYaw = {};
@@ -1600,30 +1653,6 @@ void SceneWidget::refreshVisualization()
     triggerRenderUpdate();
 }
 
-void SceneWidget::setCameraAzimuth(double angle)
-{
-    // Store the new azimuth value
-    cameraAzimuth = angle;
-
-    // Apply camera angles using helper method
-    if (currentViewMode == ViewMode::Mode3D)
-        applyCameraAnglesPreservingZoom();
-    else
-        applyCameraAngles();
-}
-
-void SceneWidget::setCameraElevation(double angle)
-{
-    // Store the new elevation value
-    cameraElevation = angle;
-
-    // Apply camera angles using helper method
-    if (currentViewMode == ViewMode::Mode3D)
-        applyCameraAnglesPreservingZoom();
-    else
-        applyCameraAngles();
-}
-
 void SceneWidget::setCameraRoll(double angle)
 {
     // Store the new roll value
@@ -1770,6 +1799,7 @@ void SceneWidget::setupInteractorStyleWithWaitCursor()
     // Cost: ~5% overhead due to ray-plane calculations
     vtkNew<CustomInteractorStyle> style;
     interactor()->SetInteractorStyle(style);
+    connectCameraCallback();
 }
 
 void SceneWidget::applyGridLinesSettings()

--- a/widgets/SceneWidget.cpp
+++ b/widgets/SceneWidget.cpp
@@ -382,7 +382,9 @@ void SceneWidget::drawVisualizationWithOptional3DSubstate()
     }
     
     // Check if we should use 3D substate visualization
-    if (! activeSubstateFor3D.empty() && settingParameter->substateInfo.count(activeSubstateFor3D) > 0)
+    if (settingParameter->numberOfSlicesZ <= 1 &&
+        ! activeSubstateFor3D.empty() &&
+        settingParameter->substateInfo.count(activeSubstateFor3D) > 0)
     {
         const auto& substateInfo = settingParameter->substateInfo[activeSubstateFor3D];
         if (! std::isnan(substateInfo.minValue) && ! std::isnan(substateInfo.maxValue))
@@ -466,7 +468,9 @@ std::vector<const SubstateInfo*> SceneWidget::getColorSubstateInfos()
 void SceneWidget::refreshVisualizationWithOptional3DSubstate()
 {
     // Check if we should use 3D substate visualization
-    if (!activeSubstateFor3D.empty() && settingParameter->substateInfo.count(activeSubstateFor3D) > 0)
+    if (settingParameter->numberOfSlicesZ <= 1 &&
+        !activeSubstateFor3D.empty() &&
+        settingParameter->substateInfo.count(activeSubstateFor3D) > 0)
     {
         const auto& substateInfo = settingParameter->substateInfo[activeSubstateFor3D];
         if (! std::isnan(substateInfo.minValue) && ! std::isnan(substateInfo.maxValue))
@@ -531,9 +535,13 @@ void SceneWidget::setupSettingParameters(const std::string& configFilename, Step
 {
     readSettingsFromConfigFile(configFilename);
 
-    // Each node has 2 lines (top and left edges)
-    // Plus additional lines for bottom edge (nNodeX lines) and right edge (nNodeY lines)
-    settingParameter->numberOfLines = 2 * (settingParameter->nNodeX * settingParameter->nNodeY) + settingParameter->nNodeX + settingParameter->nNodeY;
+    // Each node has two XY boundary lines. Final edges are tracked for every Z node layer.
+    const auto totalNodes =
+        settingParameter->nNodeX * settingParameter->nNodeY * settingParameter->nNodeZ;
+    settingParameter->numberOfLines =
+        2 * totalNodes +
+        settingParameter->nNodeX * settingParameter->nNodeZ +
+        settingParameter->nNodeY * settingParameter->nNodeZ;
     settingParameter->step = stepNumber;
     settingParameter->changed = false;
 
@@ -1690,11 +1698,17 @@ void SceneWidget::setupInteractorStyleWithWaitCursor()
 
 void SceneWidget::applyGridLinesSettings()
 {
-    // Check if we're in 3D substate mode
-    bool isIn3DMode = !activeSubstateFor3D.empty() && settingParameter && 
-                     settingParameter->substateInfo.count(activeSubstateFor3D) > 0 &&
-                     !std::isnan(settingParameter->substateInfo[activeSubstateFor3D].minValue) &&
-                     !std::isnan(settingParameter->substateInfo[activeSubstateFor3D].maxValue);
+    // Native volumes never use the flat XY node overlay. The established
+    // 2D "substate as altitude" mode keeps its surface-line behavior.
+    const bool isNative3D = settingParameter && settingParameter->numberOfSlicesZ > 1;
+    const bool isSubstateSurface =
+        !isNative3D &&
+        settingParameter &&
+        !activeSubstateFor3D.empty() &&
+        settingParameter->substateInfo.count(activeSubstateFor3D) > 0 &&
+        !std::isnan(settingParameter->substateInfo[activeSubstateFor3D].minValue) &&
+        !std::isnan(settingParameter->substateInfo[activeSubstateFor3D].maxValue);
+    const bool isIn3DMode = isNative3D || isSubstateSurface;
     
     if (isIn3DMode)
     {

--- a/widgets/SceneWidget.h
+++ b/widgets/SceneWidget.h
@@ -136,6 +136,30 @@ public:
     /// @brief Returns true when the loaded automaton has a real Z dimension.
     bool isNative3DModel() const;
 
+    /// @brief Display an axis-aligned 2D cross-section of a native 3D model.
+    void setNative3DSlice(GridSliceAxis axis, int fixedIndex);
+
+    /// @brief Return from an axis-aligned cross-section to the complete 3D volume.
+    void setNative3DVolumeView();
+
+    /// @brief Return true while a native 3D cross-section is displayed.
+    bool isNative3DSliceView() const;
+
+    /// @brief Return true when a 2D model is currently visualized as a 3D height field.
+    bool is3DSubstateSurface() const;
+
+    /// @brief Return true when the current scene can provide cross-sections.
+    bool hasSliceable3DView() const;
+
+    /// @brief Return true while any native-volume or substate cross-section is displayed.
+    bool isCrossSectionView() const;
+
+    /// @brief Display an XZ or YZ profile through the active 3D substate surface.
+    void setSubstate3DSlice(GridSliceAxis axis, int fixedIndex);
+
+    /// @brief Disable the active cross-section and restore its complete 3D source.
+    void clearCrossSection();
+
     /// @brief Get the current grid lines visibility state
     bool getGridLinesVisible() const
     {
@@ -456,6 +480,15 @@ protected:
      * @return True if coordinates are within valid grid bounds, false otherwise */
     bool convertWorldToGridCoordinates(const double worldPos[3], int& outRow, int& outCol) const;
 
+    /// @brief Number of rows in the currently rendered 2D grid or slice.
+    int displayedRowCount() const;
+
+    /// @brief Number of columns in the currently rendered 2D grid or slice.
+    int displayedColumnCount() const;
+
+    /// @brief Update 2D ruler titles for the currently selected plane.
+    void update2DRulerAxisTitles();
+
     /** @brief Check if world coordinates are within the grid bounds.
      * 
      * Determines whether the given world coordinates fall within the visible grid area.
@@ -518,6 +551,11 @@ protected:
 
     /// @brief Names of the substate fields currently used for 2D visualization (empty if using default)
     std::vector<std::string> activeSubstatesForColorring;
+
+    /// @brief Cross-section state for a 2D model rendered as a 3D substate surface.
+    bool substateSliceEnabled = false;
+    GridSliceAxis substateSliceAxis = GridSliceAxis::Y;
+    int substateSliceIndex = 0;
 
     /// @brief Current camera roll angle (cached to avoid recalculation)
     double cameraRoll{};

--- a/widgets/SceneWidget.h
+++ b/widgets/SceneWidget.h
@@ -152,31 +152,7 @@ public:
         return useCellRendering;
     }
 
-    /// @brief Set camera azimuth (rotation around Z axis) in degrees
-    void setCameraAzimuth(double angle);
-
-    /** @brief Set camera elevation (rotation around X axis).
-     * 
-     * @param angle Elevation angle in degrees */
-    void setCameraElevation(double angle);
-
-    /** @brief Get current camera azimuth.
-     * 
-     * @return Current azimuth angle in degrees */
-    double getCameraAzimuth() const
-    {
-        return cameraAzimuth;
-    }
-
-    /** @brief Get current camera elevation.
-     * 
-     * @return Current elevation angle in degrees */
-    double getCameraElevation() const
-    {
-        return cameraElevation;
-    }
-
-    /// @brief Set camera roll (rotation around Y axis) in degrees
+    /// @brief Set camera roll (rotation around X axis) in degrees
     void setCameraRoll(double angle);
 
     /** @brief Get current camera roll.
@@ -187,7 +163,7 @@ public:
         return cameraRoll;
     }
 
-    /// @brief Set camera pitch (rotation around Z axis) in degrees
+    /// @brief Set camera pitch (rotation around Y axis) in degrees
     void setCameraPitch(double angle);
 
     /** @brief Get current camera pitch.
@@ -198,7 +174,7 @@ public:
         return cameraPitch;
     }
 
-    /// @brief Set camera yaw (rotation around X axis) in degrees
+    /// @brief Set camera yaw (rotation around Z axis) in degrees
     void setCameraYaw(double angle);
 
     /** @brief Get current camera yaw.
@@ -286,13 +262,13 @@ public:
      * @param callData     Additional event-specific data (unused in this implementation). */
     static void mouseCallbackFunction(vtkObject* caller, long unsigned int eventId, void* clientData, void* callData);
 
-    /** @brief Callback function for VTK camera modified events.
+    /** @brief Callback function for VTK interactor-style rotation events.
      *
      * This function is triggered whenever the camera is modified (e.g., rotated via mouse).
      * It emits a Qt signal to notify UI elements (like sliders) to update.
      *
-     * @param caller       The VTK camera object that was modified.
-     * @param eventId      The ID of the event (expected to be vtkCommand::ModifiedEvent).
+     * @param caller       The VTK interactor style handling the gesture.
+     * @param eventId      InteractionEvent or EndInteractionEvent.
      * @param clientData   Pointer to user data (the owning SceneWidget instance).
      * @param callData     Additional event-specific data (unused). */
     static void cameraCallbackFunction(vtkObject* caller, long unsigned int eventId, void* clientData, void* callData);
@@ -310,15 +286,11 @@ signals:
      *  @param availableSteps Vector of available step numbers */
     void availableStepsReadFromConfigFile(std::vector<StepIndex> availableSteps);
 
-    /** @brief Signal emitted when camera orientation changes (e.g., via mouse interaction).
-     * 
-     * This allows UI elements (like sliders) to update when the user rotates the camera.
-     * @param azimuth Current camera azimuth in degrees
-     * @param elevation Current camera elevation in degrees
-     * @param roll Current camera roll in degrees (rotation around Y axis)
-     * @param pitch Current camera pitch in degrees (rotation around Z axis)
-     * @param yaw Current camera yaw in degrees (rotation around X axis) */
-    void cameraOrientationChanged(double azimuth, double elevation, double roll, double pitch, double yaw);
+    /** @brief Signal emitted after VTK interaction changes camera orientation.
+     * @param roll Rotation around X in degrees
+     * @param pitch Rotation around Y in degrees
+     * @param yaw Rotation around Z in degrees */
+    void cameraOrientationChanged(double roll, double pitch, double yaw);
 
 public slots:
     /** @brief Slot called when color settings need to be reloaded (at least one of them was changed)
@@ -446,13 +418,10 @@ protected:
      * Used throughout the class to update the display after modifications. */
     void triggerRenderUpdate();
 
-    /** @brief Reset camera to default position and apply stored azimuth and elevation angles.
-     * 
-     * This method resets the camera to the default top-down view, then applies
-     * the currently stored azimuth and elevation transformations. This ensures
-     * consistent camera positioning when angles are modified. */
+    /** @brief Fit the camera and apply the stored Roll/Pitch/Yaw orientation. */
     void applyCameraAngles();
 
+    /// @brief Apply stored Roll/Pitch/Yaw while preserving camera distance.
     void applyCameraAnglesPreservingZoom();
 
     /// @brief Update cached camera pivot using current visible bounds
@@ -549,12 +518,6 @@ protected:
 
     /// @brief Names of the substate fields currently used for 2D visualization (empty if using default)
     std::vector<std::string> activeSubstatesForColorring;
-
-    /// @brief Current camera azimuth angle (cached to avoid recalculation)
-    double cameraAzimuth{};
-
-    /// @brief Current camera elevation angle (cached to avoid recalculation)
-    double cameraElevation{};
 
     /// @brief Current camera roll angle (cached to avoid recalculation)
     double cameraRoll{};

--- a/widgets/SceneWidget.h
+++ b/widgets/SceneWidget.h
@@ -133,6 +133,9 @@ public:
         return currentViewMode;
     }
 
+    /// @brief Returns true when the loaded automaton has a real Z dimension.
+    bool isNative3DModel() const;
+
     /// @brief Get the current grid lines visibility state
     bool getGridLinesVisible() const
     {


### PR DESCRIPTION
The PR contains feature of displaying 3D models: https://github.com/dmacri/OOpenCal-Viewer/issues/79
<img width="868" height="625" alt="image" src="https://github.com/user-attachments/assets/11707f97-4b30-46a9-b4c0-b1d14f11412c" />


It also have possibility of 2D plane visualisation of 3D model/3D substate: https://github.com/dmacri/OOpenCal-Viewer/issues/80
<img width="1130" height="946" alt="image" src="https://github.com/user-attachments/assets/60c743ae-beae-4251-985d-f933b1a3ad92" />
_______________________________
# Description from AI:

## Summary

This PR adds end-to-end support for native 3D OOpenCAL models while preserving the existing 2D visualization and “substate as height” workflows.

Closes #79  
Closes #80

## What changed

### Native 3D model support

- Added parsing of `columns-rows-slices` dimensions.
- Added support for distributed node layouts across X, Y and Z.
- Added text and binary loading of complete 3D datasets.
- Introduced contiguous 3D grid storage shared by readers and visualizers.
- Added automatic plugin rebuilding when viewer template dependencies change.

### 3D volume rendering

- Added VTK volume rendering using `vtkImageData` and `vtkSmartVolumeMapper`.
- Added color and opacity transfer functions.
- Added lighting and shading so dark models such as Ball3D remain visibly three-dimensional.
- Added node-partition wireframes and an optional background plane.
- Native 3D models automatically open in 3D mode.

### Cross-section visualization

Cross-section controls are available through:

`View → Cross-section controls`

They are disabled by default. Hiding the controls also deactivates the current cross-section and restores the complete 3D view.

For native 3D models, the viewer supports:

- XY plane with fixed Z
- XZ plane with fixed Y
- YZ plane with fixed X

For 2D models visualized using a substate as height, it supports:

- XZ profile with fixed Y
- YZ profile with fixed X

The selected position can be changed dynamically using a slider or spin box. Tooltips and cell-value inspection use coordinates from the selected plane.

### Camera and interaction improvements

- Synchronized VTK mouse rotation with the Qt Roll/Pitch/Yaw controls.
- Made the initial camera orientation consistent with “Reset Camera”.
- Preserved full camera interaction in 3D mode.
- Disabled rotation and panning in 2D mode while keeping cursor-centered zoom.
- Automatically switches between appropriate 2D and 3D interaction modes.

### Compatibility

- Existing 2D models remain supported.
- Existing “substate as third dimension” visualization remains available.
- Cross-section support does not replace or interfere with substate coloring.
- Added the required VTK volume-rendering modules to CMake.

## Validation

- Project builds successfully with CMake.
- 44 automated tests pass.
- Tested loading the Ball3D text output, including automatic plugin rebuilding.

## Screenshots

### Native 3D volume

<img width="868" height="625" alt="Native Ball3D volume visualization" src="https://github.com/user-attachments/assets/11707f97-4b30-46a9-b4c0-b1d14f11412c" />

### 2D cross-section

<img width="1130" height="946" alt="2D cross-section visualization" src="https://github.com/user-attachments/assets/60c743ae-beae-4251-985d-f933b1a3ad92" />