### PR TITLE
Coordinates corrections

### DIFF
--- a/data/ModelReader.hpp
+++ b/data/ModelReader.hpp
@@ -363,7 +363,7 @@ void ModelReader<Cell>::readStageStateFromFilesForStep(Matrix& m, SettingParamet
 
                         if (! localStartStepDone) [[unlikely]]
                         {
-                            m[matrixRow, matrixCol, matrixSlice].startStep(sp->step);
+                            m.get(matrixRow, matrixCol, matrixSlice).startStep(sp->step);
                             localStartStepDone = true;
                         }
 
@@ -375,7 +375,7 @@ void ModelReader<Cell>::readStageStateFromFilesForStep(Matrix& m, SettingParamet
 
                         Cell tempCell;
                         std::memcpy(&tempCell, cellData, cellSize); /// @note This erases the temporary object's vtable; assignment copies the cell state.
-                        m[matrixRow, matrixCol, matrixSlice] = tempCell;
+                        m.get(matrixRow, matrixCol, matrixSlice) = tempCell;
                     }
                 }
             }
@@ -432,11 +432,11 @@ void ModelReader<Cell>::readStageStateFromFilesForStep(Matrix& m, SettingParamet
 
                         if (! localStartStepDone) [[unlikely]]
                         {
-                            m[matrixRow, matrixCol, matrixSlice].startStep(sp->step);
+                            m.get(matrixRow, matrixCol, matrixSlice).startStep(sp->step);
                             localStartStepDone = true;
                         }
 
-                        m[matrixRow, matrixCol, matrixSlice].composeElement(token);
+                        m.get(matrixRow, matrixCol, matrixSlice).composeElement(token);
                     }
                 }
             }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -743,9 +743,6 @@ void MainWindow::availableStepsLoadedFromConfigFile(std::vector<StepIndex> avail
     // Store the list of available steps for intelligent step navigation
     this->availableSteps = availableSteps;
 
-    // Update button states based on available steps
-    changeWhichButtonsAreEnabled();
-    
     // Load the first available step instead of always starting at 0
     // This handles cases where step 0 might not be available (e.g., steps [2, 4, 6, ...])
     if (!availableSteps.empty())
@@ -757,6 +754,10 @@ void MainWindow::availableStepsLoadedFromConfigFile(std::vector<StepIndex> avail
             setPositionOnWidgets(currentStep);
         }
     }
+
+    // Update button states based on available steps
+    // This must be called AFTER setting currentStep to ensure correct button states
+    changeWhichButtonsAreEnabled();
     
     const auto lastStepAvailableInAvailableSteps = std::ranges::contains(availableSteps, totalSteps());
     if (! lastStepAvailableInAvailableSteps)
@@ -1471,8 +1472,9 @@ void MainWindow::openConfigurationFile(const QString& configFileName, std::share
         // Update UI with the simulation directory that owns this Header.txt
         showInputDirectoryOnBarLabel(configFileName);
 
-        // Reset to first step
-        currentStep = 0;
+        // Reset to first available step (not always 0)
+        // This handles cases where step 0 might not be available (e.g., steps [2, 4, 6, ...])
+        currentStep = availableSteps.empty() ? FIRST_STEP_NUMBER : availableSteps.front();
         setPositionOnWidgets(currentStep);
 
         // Enable all widgets now that we have simulation data

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -746,6 +746,18 @@ void MainWindow::availableStepsLoadedFromConfigFile(std::vector<StepIndex> avail
     // Update button states based on available steps
     changeWhichButtonsAreEnabled();
     
+    // Load the first available step instead of always starting at 0
+    // This handles cases where step 0 might not be available (e.g., steps [2, 4, 6, ...])
+    if (!availableSteps.empty())
+    {
+        const StepIndex firstAvailableStep = availableSteps.front();
+        if (currentStep != firstAvailableStep)
+        {
+            currentStep = firstAvailableStep;
+            setPositionOnWidgets(currentStep);
+        }
+    }
+    
     const auto lastStepAvailableInAvailableSteps = std::ranges::contains(availableSteps, totalSteps());
     if (! lastStepAvailableInAvailableSteps)
     {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -680,6 +680,7 @@ void MainWindow::connectMenuActions()
     connect(ui->action3DMode, &QAction::triggered, this, &MainWindow::on3DModeRequested);
     connect(ui->actionCrossSectionControls, &QAction::toggled, this, &MainWindow::onCrossSectionControlsToggled);
     connect(ui->actionGridLines, &QAction::triggered, this, &MainWindow::onGridLinesToggled);
+    connect(ui->actionLineDetection, &QAction::triggered, this, &MainWindow::onLineDetectionToggled);
     connect(ui->actionFlatSceneBackground, &QAction::triggered, this, &MainWindow::onFlatSceneBackgroundToggled);
 
     /// Model selection actions are connected dynamically in createModelMenuActions()
@@ -1446,6 +1447,9 @@ void MainWindow::openConfigurationFile(const QString& configFileName, std::share
         // Synchronize grid lines checkbox with current visibility state
         syncGridLinesCheckbox();
 
+        // Synchronize line detection checkbox with current enabled state
+        syncLineDetectionCheckbox();
+
         // Synchronize flat scene background checkbox with current visibility state
         syncFlatSceneBackgroundCheckbox();
 
@@ -1906,6 +1910,18 @@ void MainWindow::syncGridLinesCheckbox()
     // Synchronize the checkbox state with the actual grid lines visibility
     QSignalBlocker blocker(ui->actionGridLines);
     ui->actionGridLines->setChecked(ui->sceneWidget->getGridLinesVisible());
+}
+
+void MainWindow::onLineDetectionToggled(bool checked)
+{
+    ui->sceneWidget->setLineDetectionEnabled(checked);
+}
+
+void MainWindow::syncLineDetectionCheckbox()
+{
+    // Synchronize the checkbox state with the actual line detection enabled state
+    QSignalBlocker blocker(ui->actionLineDetection);
+    ui->actionLineDetection->setChecked(ui->sceneWidget->getLineDetectionEnabled());
 }
 
 void MainWindow::onFlatSceneBackgroundToggled(bool checked)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -67,6 +67,8 @@ private slots: // menu actions
     void on3DModeRequested();
     void onGridLinesToggled(bool checked);
     void syncGridLinesCheckbox();
+    void onLineDetectionToggled(bool checked);
+    void syncLineDetectionCheckbox();
     void onFlatSceneBackgroundToggled(bool checked);
     void syncFlatSceneBackgroundCheckbox();
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -795,6 +795,7 @@
     <addaction name="actionCrossSectionControls"/>
     <addaction name="separator"/>
     <addaction name="actionGridLines"/>
+    <addaction name="actionLineDetection"/>
     <addaction name="actionFlatSceneBackground"/>
    </widget>
    <widget class="QMenu" name="menuSettings">
@@ -995,6 +996,20 @@
    </property>
    <property name="toolTip">
     <string>Show/hide grid lines between nodes</string>
+   </property>
+  </action>
+  <action name="actionLineDetection">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Line Detection in Tooltips</string>
+   </property>
+   <property name="toolTip">
+    <string>Enable/disable line detection when hovering with mouse (lines are detected few pixels from actual line)</string>
    </property>
   </action>
   <action name="actionFlatSceneBackground">

--- a/visualiser/Visualizer.hpp
+++ b/visualiser/Visualizer.hpp
@@ -448,14 +448,14 @@ void Visualizer::drawWithVTK3DVolume(const Volume& p,
                 double value = 0.0;
                 try
                 {
-                    value = std::stod(p[row, col, slice].stringEncoding(fieldName));
+                    value = std::stod(p.get(row, col, slice).stringEncoding(fieldName));
                 }
                 catch (...)
                 {
                     value = 0.0;
                 }
 
-                const Color color = p[row, col, slice].outputValue(fieldName, gvm);
+                const Color color = p.get(row, col, slice).outputValue(fieldName, gvm);
                 if (value < minValue)
                 {
                     minValue = value;

--- a/visualiserProxy/ContiguousGrid.h
+++ b/visualiserProxy/ContiguousGrid.h
@@ -44,6 +44,7 @@ public:
             return (rowData_[column * layerCount_]);
         }
 
+#if __cpp_multidimensional_subscript >= 202110L
         /** @brief Returns the element at the given column and layer. */
         [[nodiscard]] decltype(auto) operator[](size_type column, size_type layer) const noexcept
         {
@@ -51,6 +52,9 @@ public:
             assert(layer < layerCount_);
             return (rowData_[column * layerCount_ + layer]);
         }
+#else
+    #warning "You have old compiler, which does not support multidimensional subscript operator"
+#endif
 
     private:
         friend class ContiguousGrid;
@@ -142,6 +146,7 @@ public:
         return RowProxy<const value_type>(storage_.data() + row * columnCount_ * layerCount_, columnCount_, layerCount_);
     }
 
+#if __cpp_multidimensional_subscript >= 202110L
     /** @brief Returns a mutable element from the first layer using C++23 multidimensional subscript syntax. */
     [[nodiscard]] value_type& operator[](size_type row, size_type column) noexcept
     {
@@ -165,8 +170,8 @@ public:
     {
         return storage_[flatIndex(row, column, layer)];
     }
+#endif
 
-private:
     /** @brief Computes the storage offset for a row, column and layer triplet. */
     [[nodiscard]] size_type flatIndex(size_type row, size_type column, size_type layer) const noexcept
     {
@@ -175,6 +180,44 @@ private:
         assert(layer < layerCount_);
         return (row * columnCount_ + column) * layerCount_ + layer;
     }
+
+    /** @brief Returns a mutable element at the given row, column and layer using flat index. */
+    [[nodiscard]] value_type& at(size_type row, size_type column, size_type layer) noexcept
+    {
+        return storage_[flatIndex(row, column, layer)];
+    }
+
+    /** @brief Returns a const element at the given row, column and layer using flat index. */
+    [[nodiscard]] const value_type& at(size_type row, size_type column, size_type layer) const noexcept
+    {
+        return storage_[flatIndex(row, column, layer)];
+    }
+
+    /** @brief Returns a mutable element at the given row and column (first layer). */
+    [[nodiscard]] value_type& get(size_type row, size_type column) noexcept
+    {
+        return storage_[flatIndex(row, column, 0)];
+    }
+
+    /** @brief Returns a const element at the given row and column (first layer). */
+    [[nodiscard]] const value_type& get(size_type row, size_type column) const noexcept
+    {
+        return storage_[flatIndex(row, column, 0)];
+    }
+
+    /** @brief Returns a mutable element at the given row, column and layer. */
+    [[nodiscard]] value_type& get(size_type row, size_type column, size_type layer) noexcept
+    {
+        return storage_[flatIndex(row, column, layer)];
+    }
+
+    /** @brief Returns a const element at the given row, column and layer. */
+    [[nodiscard]] const value_type& get(size_type row, size_type column, size_type layer) const noexcept
+    {
+        return storage_[flatIndex(row, column, layer)];
+    }
+
+private:
 
     std::vector<value_type> storage_;
     size_type rowCount_ = 0;
@@ -261,6 +304,7 @@ private:
         assert(row < rowCount());
         assert(column < columnCount());
 
+#if __cpp_multidimensional_subscript >= 202110L
         switch (axis_)
         {
             case GridSliceAxis::X:
@@ -273,6 +317,21 @@ private:
 
         assert(false);
         return grid_[0, 0, 0];
+#else
+        // Fallback for compilers without C++23 multidimensional subscript support
+        switch (axis_)
+        {
+            case GridSliceAxis::X:
+                return grid_.at(column, fixedIndex_, grid_.layerCount() - 1 - row);
+            case GridSliceAxis::Y:
+                return grid_.at(fixedIndex_, column, grid_.layerCount() - 1 - row);
+            case GridSliceAxis::Z:
+                return grid_.at(row, column, fixedIndex_);
+        }
+
+        assert(false);
+        return grid_.at(0, 0, 0);
+#endif
     }
 
     const ContiguousGrid<T>& grid_;

--- a/widgets/SceneWidget.cpp
+++ b/widgets/SceneWidget.cpp
@@ -992,7 +992,7 @@ void SceneWidget::setup2DRulerAxes()
     rulerAxisX->GetPosition2Coordinate()->SetCoordinateSystemToWorld();
     rulerAxisX->SetTitle("X");
     rulerAxisX->SetNumberOfLabels(5);
-    rulerAxisX->SetLabelFormat("%.1f");
+    rulerAxisX->SetLabelFormat("%.0f");
     rulerAxisX->GetTitleTextProperty()->SetColor(1.0, 1.0, 1.0);
     rulerAxisX->GetLabelTextProperty()->SetColor(1.0, 1.0, 1.0);
     rulerAxisX->GetProperty()->SetColor(0.8, 0.8, 0.8);
@@ -1003,7 +1003,7 @@ void SceneWidget::setup2DRulerAxes()
     rulerAxisY->GetPosition2Coordinate()->SetCoordinateSystemToWorld();
     rulerAxisY->SetTitle("Y");
     rulerAxisY->SetNumberOfLabels(5);
-    rulerAxisY->SetLabelFormat("%.1f");
+    rulerAxisY->SetLabelFormat("%.0f");
     rulerAxisY->GetTitleTextProperty()->SetColor(1.0, 1.0, 1.0);
     rulerAxisY->GetLabelTextProperty()->SetColor(1.0, 1.0, 1.0);
     rulerAxisY->GetProperty()->SetColor(0.8, 0.8, 0.8);
@@ -1035,9 +1035,17 @@ void SceneWidget::update2DRulerAxesBounds()
         return; // Invalid bounds
     }
 
-    // Set range for axes (this determines the numeric labels)
-    rulerAxisX->SetRange(bounds[0], bounds[1]);
-    rulerAxisY->SetRange(bounds[2], bounds[3]);
+    const double dataWidth = bounds[1] - bounds[0];
+    const double dataHeight = bounds[3] - bounds[2];
+
+    // Set user-facing pixel ranges for axes. VTK world Y grows upward, but image
+    // coordinates grow downward, so the grid Y ruler is intentionally reversed:
+    // top label = 0, bottom label = data height. Do not apply this to vertical
+    // altitude/Z cross-section axes.
+    rulerAxisX->SetRange(0.0, dataWidth);
+    const bool verticalTopOrigin = verticalRulerUsesTopOrigin();
+    rulerAxisY->SetRange(verticalTopOrigin ? dataHeight : 0.0,
+                         verticalTopOrigin ? 0.0 : dataHeight);
 
     // Position X axis at the bottom of the data (horizontal line)
     rulerAxisX->GetPositionCoordinate()->SetValue(bounds[0], bounds[2], 0.0);
@@ -1047,8 +1055,10 @@ void SceneWidget::update2DRulerAxesBounds()
     rulerAxisY->GetPositionCoordinate()->SetValue(bounds[1], bounds[2], 0.0);
     rulerAxisY->GetPosition2Coordinate()->SetValue(bounds[1], bounds[3], 0.0);
 
-    std::cout << "Ruler axes updated: X=[" << bounds[0] << ", " << bounds[1]
-              << "], Y=[" << bounds[2] << ", " << bounds[3] << "]" << std::endl;
+    std::cout << "Ruler axes updated: X=[0, " << dataWidth
+              << "], vertical=[" << (verticalTopOrigin ? dataHeight : 0.0)
+              << ", " << (verticalTopOrigin ? 0.0 : dataHeight)
+              << "]" << std::endl;
 }
 
 void SceneWidget::update2DRulerAxisTitles()
@@ -1082,6 +1092,19 @@ void SceneWidget::update2DRulerAxisTitles()
 
     rulerAxisX->SetTitle(horizontalAxis);
     rulerAxisY->SetTitle(verticalAxis);
+}
+
+bool SceneWidget::verticalRulerUsesTopOrigin() const
+{
+    if (substateSliceEnabled)
+        return false;
+
+    if (isNative3DSliceView())
+    {
+        return sceneWidgetVisualizerProxy->native3DSliceAxis() == GridSliceAxis::Z;
+    }
+
+    return true;
 }
 
 void SceneWidget::connectKeyboardCallback()
@@ -1218,17 +1241,23 @@ void SceneWidget::mouseCallbackFunction(vtkObject* caller, long unsigned int eve
 
     const auto lastMousePos = QPoint(vtkX, qtY);
 
-    // 3) Use a picker to obtain an accurate world position (if something was "hit")
+    self->m_lastMousePickedGrid = false;
+
+    // 3) Use a picker restricted to the data grid actor. Picking any visible prop
+    // would also hit ruler axes or load-balancing helper lines, which can make a
+    // tooltip appear when the cursor is visually outside the simulation grid.
     vtkNew<vtkPropPicker> picker;
     bool picked = false;
-    if (self->renderer)
+    if (self->renderer && self->gridActor)
     {
-        // Pick returns 1 if something was hit (depending on the picker). Pass the renderer.
+        picker->PickFromListOn();
+        picker->AddPickList(self->gridActor);
         if (picker->Pick(vtkX, vtkY, 0.0, self->renderer))
         {
             double pickPos[3];
             picker->GetPickPosition(pickPos);
             self->m_lastWorldPos = { pickPos[0], pickPos[1], pickPos[2] };
+            self->m_lastMousePickedGrid = true;
             picked = true;
         }
     }
@@ -1340,7 +1369,7 @@ std::array<double, 3> SceneWidget::screenToWorldCoordinates(const QPoint& pos) c
 
 QString SceneWidget::getNodeAtWorldPosition(const std::array<double, 3>& worldPos) const
 {
-    if (! settingParameter || ! sceneWidgetVisualizerProxy || ! renderer)
+    if (! settingParameter || ! sceneWidgetVisualizerProxy)
     {
         return {};
     }
@@ -1351,9 +1380,8 @@ QString SceneWidget::getNodeAtWorldPosition(const std::array<double, 3>& worldPo
         return {}; // Outside scene bounds
     }
 
-    // Get the bounds of the entire scene
-    const double* bounds = renderer->ComputeVisiblePropBounds();
-    if (! bounds)
+    double bounds[6];
+    if (! currentGridBounds(bounds))
     {
         return {};
     }
@@ -1367,7 +1395,8 @@ QString SceneWidget::getNodeAtWorldPosition(const std::array<double, 3>& worldPo
 
     // Calculate which node the position is in (0-based indices)
     const int nodeX = static_cast<int>((worldPos[0] - bounds[0]) / nodeWidth);
-    const int nodeY = static_cast<int>((worldPos[1] - bounds[2]) / nodeHeight);
+    const int nodeYFromBottom = static_cast<int>((worldPos[1] - bounds[2]) / nodeHeight);
+    const int nodeY = static_cast<int>(settingParameter->nNodeY) - 1 - nodeYFromBottom;
 
     // Check if the calculated node is within bounds
     if (nodeX >= 0 && nodeX < static_cast<int>(settingParameter->nNodeX) &&
@@ -1443,7 +1472,7 @@ void SceneWidget::updateToolTip(const QPoint& lastMousePos)
     if (! renderer || ! renderWindow())
         return;
 
-    if (isCrossSectionView() && isWorldPositionInGrid(m_lastWorldPos.data()))
+    if (m_lastMousePickedGrid && isCrossSectionView() && isWorldPositionInGrid(m_lastWorldPos.data()))
     {
         int planeRow = 0;
         int planeColumn = 0;
@@ -1512,23 +1541,34 @@ void SceneWidget::updateToolTip(const QPoint& lastMousePos)
     {
         tooltipText += QString("Line %1/%2:").arg(lineIndex).arg(lines.size());
         tooltipText += QString("\n  From: (x1=%1, y1=%2)")
-                           .arg(nearestLine->x1, 0, 'f', 2)
-                           .arg(nearestLine->y1, 0, 'f', 2);
+                           .arg(static_cast<int>(std::lround(nearestLine->x1)))
+                           .arg(static_cast<int>(std::lround(nearestLine->y1)));
         tooltipText += QString("\n  To:   (x2=%1, y2=%2)")
-                           .arg(nearestLine->x2, 0, 'f', 2)
-                           .arg(nearestLine->y2, 0, 'f', 2);
+                           .arg(static_cast<int>(std::lround(nearestLine->x2)))
+                           .arg(static_cast<int>(std::lround(nearestLine->y2)));
         tooltipText += cellValueAtThisPositionAsText();
     }
-    else if (QString nodeInfo = getNodeAtWorldPosition(m_lastWorldPos); ! nodeInfo.isEmpty())
+    else if (m_lastMousePickedGrid)
     {
-        tooltipText = QString("World Position: (x: %1, y: %2, z: %3)")
-                          .arg(m_lastWorldPos[0], 0, 'f', 2)
-                          .arg(m_lastWorldPos[1], 0, 'f', 2)
-                          .arg(m_lastWorldPos[2], 0, 'f', 2);
+        int displayX = 0;
+        int displayY = 0;
+        int displayZ = 0;
+        const QString nodeInfo = getNodeAtWorldPosition(m_lastWorldPos);
+        if (nodeInfo.isEmpty() || !convertWorldToDisplayCoordinates(m_lastWorldPos.data(), displayX, displayY, displayZ))
+        {
+            tooltipText = "(Outside the grid)";
+        }
+        else
+        {
+            tooltipText = QString("Pixel Position: (x: %1, y: %2, z: %3)")
+                              .arg(displayX)
+                              .arg(displayY)
+                              .arg(displayZ);
 
-        tooltipText += QString("\n%1").arg(nodeInfo);
+            tooltipText += QString("\n%1").arg(nodeInfo);
 
-        tooltipText += cellValueAtThisPositionAsText();
+            tooltipText += cellValueAtThisPositionAsText();
+        }
     }
     else
         tooltipText = "(Outside the grid)";
@@ -1540,6 +1580,9 @@ void SceneWidget::updateToolTip(const QPoint& lastMousePos)
 QString SceneWidget::cellValueAtThisPositionAsText() const
 {
     if (!sceneWidgetVisualizerProxy || !settingParameter)
+        return {};
+
+    if (!m_lastMousePickedGrid)
         return {};
 
     int row = 0, col = 0;
@@ -2110,7 +2153,7 @@ void SceneWidget::mousePressEvent(QMouseEvent* event)
     if (m_substatesDockWidget && sceneWidgetVisualizerProxy && event->button() == Qt::LeftButton && !(event->modifiers() & Qt::ShiftModifier))
     {
         // Check if click was inside the grid
-        if (isWorldPositionInGrid(m_lastWorldPos.data()))
+        if (m_lastMousePickedGrid && isWorldPositionInGrid(m_lastWorldPos.data()))
         {
             int row = 0, col = 0;
             if (convertWorldToGridCoordinates(m_lastWorldPos.data(), row, col))
@@ -2131,12 +2174,11 @@ void SceneWidget::mousePressEvent(QMouseEvent* event)
 
 bool SceneWidget::convertWorldToGridCoordinates(const double worldPos[3], int& outRow, int& outCol) const
 {
-    if (!renderer || !settingParameter)
+    if (!settingParameter)
         return false;
 
-    // Get the bounds of the entire scene
-    const double* bounds = renderer->ComputeVisiblePropBounds();
-    if (! bounds)
+    double bounds[6];
+    if (! currentGridBounds(bounds) || ! isWorldPositionInGrid(worldPos))
         return false;
 
     // Calculate grid dimensions
@@ -2194,6 +2236,31 @@ bool SceneWidget::convertWorldToGridCoordinates(const double worldPos[3], int& o
     return true;
 }
 
+bool SceneWidget::currentGridBounds(double bounds[6]) const
+{
+    if (!gridActor)
+        return false;
+
+    gridActor->GetBounds(bounds);
+
+    return std::isfinite(bounds[0]) && std::isfinite(bounds[1]) &&
+           std::isfinite(bounds[2]) && std::isfinite(bounds[3]) &&
+           bounds[0] < bounds[1] && bounds[2] < bounds[3];
+}
+
+bool SceneWidget::convertWorldToDisplayCoordinates(const double worldPos[3], int& outX, int& outY, int& outZ) const
+{
+    double bounds[6];
+    if (! currentGridBounds(bounds) || ! isWorldPositionInGrid(worldPos))
+        return false;
+
+    outX = static_cast<int>(std::lround(worldPos[0] - bounds[0]));
+    outY = static_cast<int>(std::lround(bounds[3] - worldPos[1]));
+    outZ = static_cast<int>(std::lround(worldPos[2]));
+
+    return true;
+}
+
 int SceneWidget::displayedRowCount() const
 {
     if (!settingParameter)
@@ -2220,12 +2287,11 @@ int SceneWidget::displayedColumnCount() const
 
 bool SceneWidget::isWorldPositionInGrid(const double worldPos[3]) const
 {
-    if (!renderer || !settingParameter)
+    if (!settingParameter)
         return false;
 
-    // Get the bounds of the entire scene
-    const double* bounds = renderer->ComputeVisiblePropBounds();
-    if (! bounds)
+    double bounds[6];
+    if (! currentGridBounds(bounds))
         return false;
 
     // Check if position is within grid bounds

--- a/widgets/SceneWidget.cpp
+++ b/widgets/SceneWidget.cpp
@@ -1529,10 +1529,14 @@ void SceneWidget::updateToolTip(const QPoint& lastMousePos)
     // m_lastMousePos is already in Qt coordinates (origin: top-left)
     // m_lastWorldPos is set by the VTK callback (picker or DisplayToWorld fallback)
 
-    // Check if we're over a line
+    // Check if we're over a line (only if line detection is enabled)
     size_t lineIndex = 0;
     double distanceSq = 0.0;
-    const Line* nearestLine = findNearestLine(m_lastWorldPos, lineIndex, distanceSq);
+    const Line* nearestLine = nullptr;
+    if (lineDetectionEnabled)
+    {
+        nearestLine = findNearestLine(m_lastWorldPos, lineIndex, distanceSq);
+    }
 
     // Prepare tooltip text
     QString tooltipText;
@@ -2031,10 +2035,15 @@ void SceneWidget::setAxesWidgetVisible(bool visible)
 void SceneWidget::setGridLinesVisible(bool visible)
 {
     gridLinesVisible = visible;
-    
+
     applyGridLinesSettings();
-    
+
     triggerRenderUpdate();
+}
+
+void SceneWidget::setLineDetectionEnabled(bool enabled)
+{
+    lineDetectionEnabled = enabled;
 }
 
 void SceneWidget::setFlatSceneBackgroundVisible(bool visible)

--- a/widgets/SceneWidget.h
+++ b/widgets/SceneWidget.h
@@ -485,6 +485,23 @@ protected:
      * @return True if coordinates are within valid grid bounds, false otherwise */
     bool convertWorldToGridCoordinates(const double worldPos[3], int& outRow, int& outCol) const;
 
+    /** @brief Returns bounds of the rendered data grid actor, excluding ruler axes and helper props.
+     *  @param bounds Output VTK bounds array: xmin, xmax, ymin, ymax, zmin, zmax
+     *  @return True if bounds are available and finite. */
+    bool currentGridBounds(double bounds[6]) const;
+
+    /** @brief Converts VTK world coordinates to display/pixel coordinates shown to users.
+     *
+     *  X grows from left to right. Y grows from top to bottom, matching image/pixel
+     *  coordinates and the 2D ruler labels.
+     *
+     *  @param worldPos VTK world coordinates
+     *  @param outX User-facing X coordinate
+     *  @param outY User-facing Y coordinate
+     *  @param outZ User-facing Z coordinate
+     *  @return True if the position is inside the rendered data grid. */
+    bool convertWorldToDisplayCoordinates(const double worldPos[3], int& outX, int& outY, int& outZ) const;
+
     /// @brief Number of rows in the currently rendered 2D grid or slice.
     int displayedRowCount() const;
 
@@ -493,6 +510,9 @@ protected:
 
     /// @brief Update 2D ruler titles for the currently selected plane.
     void update2DRulerAxisTitles();
+
+    /// @brief Returns true when the vertical ruler represents screen/grid Y coordinates.
+    bool verticalRulerUsesTopOrigin() const;
 
     /** @brief Check if world coordinates are within the grid bounds.
      * 
@@ -585,6 +605,9 @@ protected:
 
     /** @brief Last recorded position in VTK world coordinates. */
     std::array<double, 3> m_lastWorldPos;
+
+    /** @brief Whether the last mouse move picked the rendered data grid actor. */
+    bool m_lastMousePickedGrid = false;
 
     /// @brief VTK renderer for the scene: This renderer is responsible for rendering the 3D scene.
     vtkNew<vtkRenderer> renderer;

--- a/widgets/SceneWidget.h
+++ b/widgets/SceneWidget.h
@@ -117,6 +117,16 @@ public:
     /// @param visible If true, shows grid lines; if false, hides them
     void setGridLinesVisible(bool visible);
 
+    /// @brief Enable or disable line detection in tooltips
+    /// @param enabled If true, enables line detection; if false, disables it
+    void setLineDetectionEnabled(bool enabled);
+
+    /// @brief Get the current line detection enabled state
+    bool getLineDetectionEnabled() const
+    {
+        return lineDetectionEnabled;
+    }
+
     /// @brief Show or hide flat scene background in 3D mode
     /// @param visible If true, shows flat background; if false, hides it
     void setFlatSceneBackgroundVisible(bool visible);
@@ -573,6 +583,9 @@ protected:
 
     /// @brief Current grid lines visibility state
     bool gridLinesVisible = true;
+
+    /// @brief Line detection in tooltip visibility state
+    bool lineDetectionEnabled = true;
 
     /// @brief Flat scene background visibility state (shown in 3D mode)
     bool flatSceneBackgroundVisible = true;


### PR DESCRIPTION
This task implements 3 issues:

# 1: 0 on the top, not on the botton
https://github.com/dmacri/OOpenCal-Viewer/issues/118
Currently it is opposite:

<img width="1132" height="872" alt="image" src="https://github.com/user-attachments/assets/0d2bae58-4c5e-4fdd-91b7-261b7683cab6" />

# 2 Coordinates should be integers
https://github.com/dmacri/OOpenCal-Viewer/issues/117
(as on the previous screen)

<img width="1132" height="872" alt="image" src="https://github.com/user-attachments/assets/b008508b-9c41-40ae-8547-d468af30be3c" />

# 3 Correct coordinates out of the grid:
https://github.com/dmacri/OOpenCal-Viewer/issues/120 (first image)

<img width="1132" height="872" alt="image" src="https://github.com/user-attachments/assets/12c89c4b-09e1-4fbc-8143-2afc15dfefac" />

